### PR TITLE
D'oh, socializing and fixing .cabal is bad.  Fixing the fix.

### DIFF
--- a/llvm-pretty-bc-parser.cabal
+++ b/llvm-pretty-bc-parser.cabal
@@ -69,7 +69,8 @@ Executable llvm-disasm
                        fgl        >= 5.5,
                        fgl-visualize >= 0.1,
                        cereal     >= 0.3.5.2,
-                       llvm-pretty>= 0.5
+                       llvm-pretty>= 0.5,
+                       llvm-pretty-bc-parser
 
 Test-suite disasm-test
   type:                exitcode-stdio-1.0
@@ -82,4 +83,5 @@ Test-suite disasm-test
                        directory,
                        bytestring,
                        filepath,
-                       llvm-pretty>= 0.5
+                       llvm-pretty>= 0.5,
+                       llvm-pretty-bc-parser


### PR DESCRIPTION
Missed the .cabal was defining multiple executables that used said library.