### PR TITLE
Add an new tool `llvm-ast` which is default non-buildable.

### DIFF
--- a/llvm-ast/LLVMast.hs
+++ b/llvm-ast/LLVMast.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE ImplicitParams #-}
+import Data.LLVM.BitCode (parseBitCode, formatError)
+
+import Control.Monad (when)
+import Data.Monoid (mconcat, Endo(..))
+import System.Console.GetOpt
+  (ArgOrder(..), ArgDescr(..), OptDescr(..), getOpt, usageInfo)
+import System.Environment (getArgs,getProgName)
+import System.Exit (exitFailure, exitSuccess)
+import System.IO (stderr,hPutStrLn)
+import Text.Show.Pretty
+import qualified Data.ByteString as S
+
+data Options = Options {
+    optHelp        :: Bool
+  } deriving (Show)
+
+defaultOptions :: Options
+defaultOptions  = Options {
+    optHelp        = False
+  }
+
+options :: [OptDescr (Endo Options)]
+options  =
+  [ Option "h" ["help"] (NoArg setHelp)
+    "display this message"
+  ]
+
+getOptions :: IO (Options, [FilePath])
+getOptions =
+  do args <- getArgs
+     case getOpt RequireOrder options args of
+       (fs,files@(_:_),[]) -> do
+         let opts = appEndo (mconcat fs) defaultOptions
+         when (optHelp opts) $
+           printUsage [] >> exitSuccess
+         return (opts,files)
+       (_,_,errs) -> do printUsage errs
+                        exitFailure
+
+printUsage :: [String] -> IO ()
+printUsage errs =
+  do prog <- getProgName
+     let banner = "Usage: " ++ prog ++ " [OPTIONS]"
+     putStrLn (usageInfo (unlines (errs ++ [banner])) options)
+
+setHelp :: Endo Options
+setHelp = Endo (\opt -> opt { optHelp = True })
+
+main :: IO ()
+main  = do
+  (opts, files) <- getOptions
+  mapM_ (ppAST opts) files
+
+ppAST :: Options -> [Char] -> IO ()
+ppAST opts file = do
+  putStrLn (replicate 80 '-' ++ "\n")
+  putStrLn ("-- " ++ file)
+  e <- parseBitCode =<< S.readFile file
+  case e of
+
+    Left err -> do
+      hPutStrLn stderr (formatError err)
+      exitFailure
+
+    Right m  -> do
+        putStrLn $ ppShow m

--- a/llvm-pretty-bc-parser.cabal
+++ b/llvm-pretty-bc-parser.cabal
@@ -19,6 +19,10 @@ Flag fuzz
   Description:         Enable fuzzing harness
   Default:             False
 
+Flag ast
+  Description:         Enable llvm-ast, pretty printing ASTs for dev work.
+  Default:             False
+
 Source-repository head
   type:                git
   location:            http://github.com/galoisinc/llvm-pretty-bc-parser
@@ -75,6 +79,26 @@ Executable llvm-disasm
                        cereal     >= 0.3.5.2,
                        llvm-pretty>= 0.7.1.0,
                        llvm-pretty-bc-parser
+
+Executable llvm-ast
+  Main-is:             LLVMast.hs
+  Default-language:    Haskell2010
+  Ghc-options:         -Wall
+  Hs-source-dirs:      llvm-ast
+  Build-depends:       bytestring >= 0.9.1,
+                       base       >= 4 && < 5,
+                       pretty     >= 1.0.1,
+                       containers >= 0.4,
+                       array      >= 0.3,
+                       monadLib   >= 3.7.2,
+                       cereal     >= 0.3.5.2,
+                       llvm-pretty>= 0.7.1.0,
+                       llvm-pretty-bc-parser,
+                       pretty-show
+  if flag(ast)
+      Buildable:       True
+  else
+      Buildable:       False
 
 Test-suite disasm-test
   type:                exitcode-stdio-1.0

--- a/src/Data/LLVM/BitCode/IR/Globals.hs
+++ b/src/Data/LLVM/BitCode/IR/Globals.hs
@@ -56,9 +56,7 @@ parseGlobalVar n r = label "GLOBALVAR" $ do
   let valid | initid == 0 = Nothing
             | otherwise   = Just (initid - 1)
       attrs = GlobalAttrs
-        { gaLinkage    = do
-          guard (link /= External)
-          return link
+        { gaLinkage    = Just link
         , gaConstant   = isconst
         }
 


### PR DESCRIPTION
I find myself reproducing this tool too often.  Here is an example use:

```
echo 'int main() { return 54; }' >> test.c
clang -c -emit-llvm test.c
llvm-ast test.bc
```
It might be a neat future feature to include an interpreter, via `hint`, and pass in Haskell expressions of type `Show a => Module -> a` to allow user extraction of fields of the module for printing.