### PR TITLE
Fix parse of fast math field.

### DIFF
--- a/src/Data/LLVM/BitCode/IR/Function.hs
+++ b/src/Data/LLVM/BitCode/IR/Function.hs
@@ -820,8 +820,8 @@ parseFunctionBlockEntry _ t d (fromEntry -> Just r) = case recordCode r of
                                   return () ]
 
     -- XXX: we're ignoring the fast math flags
-    let ix1 | isfp && length (recordFields r) > ix0 + 1 = ix0 + 1
-            | otherwise                                 = ix0
+    let ix1 | isfp && length (recordFields r) > 3 = ix0 + 1
+            | otherwise                           = ix0
 
     rhs <- getValue t (typedType lhs) =<< field ix1 numeric
 


### PR DESCRIPTION
This "fix" doesn't appear to match my reading of the llvm C++ source (Bitcodereader.cpp) but our reading of the fast math flag appears incorrect. Without this fix we can not parse zstd bitcode.

@atomb and the saw team in general.  I need this patch if I am to analyze certain bitcodes.  While I feel the behavior is an improvement I am not confident this patch does "the right thing" in all cases.  Should we merge?  Should we find someone to take point w/ hours to back them? I'd rather not accept the current broken behavior (i.e. fail to merge and fail to fix).