### PR TITLE
Metadata: Use applicative parsing style

### DIFF
--- a/src/Data/LLVM/BitCode/IR/Metadata.hs
+++ b/src/Data/LLVM/BitCode/IR/Metadata.hs
@@ -1,7 +1,8 @@
-{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE ExplicitForAll #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE RecursiveDo #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Data.LLVM.BitCode.IR.Metadata (
     parseMetadataBlock
@@ -25,6 +26,7 @@ import Text.LLVM.Labels
 import qualified Codec.Binary.UTF8.String as UTF8 (decode)
 import Control.Exception (throw)
 import Control.Monad (foldM,guard,mplus,unless,when)
+import Data.Functor.Compose (Compose(..), getCompose)
 import Data.List (mapAccumL)
 import Data.Maybe (fromMaybe)
 import Data.Bits (shiftR, testBit, shiftL)
@@ -265,6 +267,29 @@ parsedMetadata pm =
   , pmGlobalAttachments pm
   )
 
+-- Applicative composition ------------------------------------------------------------
+
+-- Some utilities for dealing with composition of applicatives
+
+-- | These are useful for avoiding writing 'Compose'
+(<$$>) :: forall f g a b. (Functor f, Functor g)
+       => (a -> b) -> (f (g a)) -> Compose f g b
+h <$$> x = h <$> Compose x
+
+(<**>) :: forall f g a b. (Applicative f, Applicative g)
+       => Compose f g (a -> b) -> (f (g a)) -> Compose f g b
+h <**> x = h <*> Compose x
+
+-- | These are useful for avoiding writing 'pure'
+-- (i.e. only some parts of your long applicative chain use both effects)
+(<<*>) :: forall f g a b. (Applicative f, Applicative g)
+       => Compose f g (a -> b) -> (f a) -> Compose f g b
+h <<*> x = h <*> Compose (pure <$> x)
+
+(<*>>) :: forall f g a b. (Applicative f, Applicative g)
+       => Compose f g (a -> b) -> (g a) -> Compose f g b
+h <*>> x = h <*> Compose (pure x)
+
 -- Metadata Parsing ------------------------------------------------------------
 
 parseMetadataBlock ::
@@ -333,14 +358,14 @@ parseMetadataEntry vt mt pm (fromEntry -> Just r) =
     -- TODO: broken in 3.7+; needs to be a DILocation rather than an
     -- MDLocation, but there appears to be no difference in the
     -- bitcode. /sigh/
-    cxt       <- getContext
     let field = parseField r
+    cxt        <- getContext
     isDistinct <- field 0 nonzero
-    dlLine     <- field 1 numeric
-    dlCol      <- field 2 numeric
-    dlScope    <- mdForwardRef cxt mt <$> field 3 numeric
-    dlIA       <- mdForwardRefOrNull cxt mt <$> field 4 numeric
-    let loc = DebugLoc { .. }
+    loc        <- DebugLoc
+      <$> field 1 numeric                                 -- dlLine
+      <*> field 2 numeric                                 -- dlCol
+      <*> (mdForwardRef       cxt mt <$> field 3 numeric) -- dlScope
+      <*> (mdForwardRefOrNull cxt mt <$> field 4 numeric) -- dlIA
     return $! updateMetadataTable (addLoc isDistinct loc) pm
 
 
@@ -362,15 +387,15 @@ parseMetadataEntry vt mt pm (fromEntry -> Just r) =
     let recordSize = length (recordFields r)
     when (recordSize == 0)
       (fail "Invalid record")
-    if (recordSize `mod` 2 == 0)
-      then label "function attachment" $ do
-        att <- Map.fromList <$> parseAttachment r 0
-        return $! addFnAttachment att pm
-      else label "instruction attachment" $ do
-        inst <- parseField r 0 numeric
-        patt <- parseAttachment r 1
-        att <- mapM (\(k,md) -> (,md) <$> getKind k) patt
-        return $! addInstrAttachment inst att pm
+    if recordSize `mod` 2 == 0
+    then label "function attachment" $ do
+      att <- Map.fromList <$> parseAttachment r 0
+      return $! addFnAttachment att pm
+    else label "instruction attachment" $ do
+      inst <- parseField r 0 numeric
+      patt <- parseAttachment r 1
+      att <- mapM (\(k,md) -> (,md) <$> getKind k) patt
+      return $! addInstrAttachment inst att pm
 
   12 -> label "METADATA_GENERIC_DEBUG" $ do
     --isDistinct <- parseField r 0 numeric
@@ -381,89 +406,92 @@ parseMetadataEntry vt mt pm (fromEntry -> Just r) =
     fail "not yet implemented"
 
   13 -> label "METADATA_SUBRANGE" $ do
-    isDistinct <- parseField r 0 nonzero
-    disrCount <- parseField r 1 numeric
-    disrLowerBound <- parseField r 2 signedInt64
+    isDistinct     <- parseField r 0 nonzero
+    diNode         <- DISubrange
+      <$> parseField r 1 numeric     -- disrCount
+      <*> parseField r 2 signedInt64 -- disrLowerBound
     return $! updateMetadataTable
-      (addDebugInfo isDistinct (DebugInfoSubrange DISubrange{..})) pm
+      (addDebugInfo isDistinct (DebugInfoSubrange diNode)) pm
 
   -- [distinct, value, name]
   14 -> label "METADATA_ENUMERATOR" $ do
     ctx        <- getContext
     isDistinct <- parseField r 0 nonzero
-    value      <- parseField r 1 signedInt64
-    name       <- mdString ctx mt <$> parseField r 2 numeric
-    return $! updateMetadataTable
-      (addDebugInfo isDistinct (DebugInfoEnumerator name value)) pm
+    diEnum     <- flip DebugInfoEnumerator
+      <$> parseField r 1 signedInt64                   -- value
+      <*> (mdString ctx mt <$> parseField r 2 numeric) -- name
+    return $! updateMetadataTable (addDebugInfo isDistinct diEnum) pm
 
   15 -> label "METADATA_BASIC_TYPE" $ do
     ctx <- getContext
     isDistinct <- parseField r 0 nonzero
-    dibtTag <- parseField r 1 numeric
-    dibtName <- mdString ctx mt <$> parseField r 2 numeric
-    dibtSize <- parseField r 3 numeric
-    dibtAlign <- parseField r 4 numeric
-    dibtEncoding <- parseField r 5 numeric
+    dibt <- DIBasicType
+      <$> parseField r 1 numeric                       -- dibtTag
+      <*> (mdString ctx mt <$> parseField r 2 numeric) -- dibtName
+      <*> parseField r 3 numeric                       -- dibtSize
+      <*> parseField r 4 numeric                       -- dibtAlign
+      <*> parseField r 5 numeric                       -- dibtEncoding
     return $! updateMetadataTable
-      (addDebugInfo isDistinct (DebugInfoBasicType DIBasicType{..})) pm
+      (addDebugInfo isDistinct (DebugInfoBasicType dibt)) pm
 
   -- [distinct, filename, directory]
   16 -> label "METADATA_FILE" $ do
-    ctx <- getContext
+    ctx        <- getContext
     isDistinct <- parseField r 0 nonzero
-    difFilename <- mdString ctx mt <$> parseField r 1 numeric
-    difDirectory <- mdString ctx mt <$> parseField r 2 numeric
+    diFile     <- DIFile
+      <$> (mdString ctx mt <$> parseField r 1 numeric) -- difFilename
+      <*> (mdString ctx mt <$> parseField r 2 numeric) -- difDirectory
     return $! updateMetadataTable
-      (addDebugInfo isDistinct (DebugInfoFile DIFile{..})) pm
+      (addDebugInfo isDistinct (DebugInfoFile diFile)) pm
 
   17 -> label "METADATA_DERIVED_TYPE" $ do
-    ctx <- getContext
-    isDistinct    <- parseField r 0 nonzero
-    didtTag       <- parseField r 1 numeric
-    didtName      <- mdStringOrNull     ctx mt <$> parseField r 2 numeric
-    didtFile      <- mdForwardRefOrNull ctx mt <$> parseField r 3 numeric
-    didtLine      <- parseField r 4 numeric
-    didtScope     <- mdForwardRefOrNull ctx mt <$> parseField r 5 numeric
-    didtBaseType  <- mdForwardRefOrNull ctx mt <$> parseField r 6 numeric
-    didtSize      <- parseField r 7 numeric
-    didtAlign     <- parseField r 8 numeric
-    didtOffset    <- parseField r 9 numeric
-    didtFlags     <- parseField r 10 numeric
-    didtExtraData <- mdForwardRefOrNull ctx mt <$> parseField r 11 numeric
+    ctx        <- getContext
+    isDistinct <- parseField r 0 nonzero
+    didt       <- DIDerivedType
+      <$> parseField r 1 numeric -- didtTag
+      <*> (mdStringOrNull     ctx mt <$> parseField r 2 numeric)  -- didtName
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r 3 numeric)  -- didtFile
+      <*> parseField r 4 numeric                                  -- didtLine
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r 5 numeric)  -- didtScope
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r 6 numeric)  -- didtBaseType
+      <*> parseField r 7 numeric                                  -- didtSize
+      <*> parseField r 8 numeric                                  -- didtAlign
+      <*> parseField r 9 numeric                                  -- didtOffset
+      <*> parseField r 10 numeric                                 -- didtFlags
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r 11 numeric) -- didtExtraData
     return $! updateMetadataTable
-      (addDebugInfo isDistinct (DebugInfoDerivedType DIDerivedType{..})) pm
+      (addDebugInfo isDistinct (DebugInfoDerivedType didt)) pm
 
   18 -> label "METADATA_COMPOSITE_TYPE" $ do
-    ctx <- getContext
-    isDistinct         <- parseField r 0 nonzero
-    dictTag            <- parseField r 1 numeric
-    dictName           <- mdStringOrNull     ctx mt <$> parseField r 2 numeric
-    dictFile           <- mdForwardRefOrNull ctx mt <$> parseField r 3 numeric
-    dictLine           <- parseField r 4 numeric
-    dictScope          <- mdForwardRefOrNull ctx mt <$> parseField r 5 numeric
-    dictBaseType       <- mdForwardRefOrNull ctx mt <$> parseField r 6 numeric
-    dictSize           <- parseField r 7 numeric
-    dictAlign          <- parseField r 8 numeric
-    dictOffset         <- parseField r 9 numeric
-    dictFlags          <- parseField r 10 numeric
-    dictElements       <- mdForwardRefOrNull ctx mt <$> parseField r 11 numeric
-    dictRuntimeLang    <- parseField r 12 numeric
-    dictVTableHolder   <- mdForwardRefOrNull ctx mt <$> parseField r 13 numeric
-    dictTemplateParams <- mdForwardRefOrNull ctx mt <$> parseField r 14 numeric
-    dictIdentifier     <- mdStringOrNull     ctx mt <$> parseField r 15 numeric
+    ctx        <- getContext
+    isDistinct <- parseField r 0 nonzero
+    dict       <- DICompositeType
+      <$> parseField r 1 numeric                                  -- dictTag
+      <*> (mdStringOrNull     ctx mt <$> parseField r 2 numeric)  -- dictName
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r 3 numeric)  -- dictFile
+      <*> parseField r 4 numeric                                  -- dictLine
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r 5 numeric)  -- dictScope
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r 6 numeric)  -- dictBaseType
+      <*> parseField r 7 numeric                                  -- dictSize
+      <*> parseField r 8 numeric                                  -- dictAlign
+      <*> parseField r 9 numeric                                  -- dictOffset
+      <*> parseField r 10 numeric                                 -- dictFlags
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r 11 numeric) -- dictElements
+      <*> parseField r 12 numeric                                 -- dictRuntimeLang
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r 13 numeric) -- dictVTableHolder
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r 14 numeric) -- dictTemplateParams
+      <*> (mdStringOrNull     ctx mt <$> parseField r 15 numeric) -- dictIdentifier
     return $! updateMetadataTable
-      (addDebugInfo isDistinct (DebugInfoCompositeType DICompositeType{..})) pm
+      (addDebugInfo isDistinct (DebugInfoCompositeType dict)) pm
 
   19 -> label "METADATA_SUBROUTINE_TYPE" $ do
     ctx <- getContext
     isDistinct    <- parseField r 0 nonzero
-    distFlags     <- parseField r 1 numeric
-    distTypeArray <- mdForwardRefOrNull ctx mt <$> parseField r 2 numeric
+    dist <- DISubroutineType
+      <$> parseField r 1 numeric                                 -- distFlags
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r 2 numeric) -- distTypeArray
     return $! updateMetadataTable
-      (addDebugInfo
-         isDistinct
-         (DebugInfoSubroutineType DISubroutineType{..}))
-      pm
+      (addDebugInfo isDistinct (DebugInfoSubroutineType dist)) pm
 
   20 -> label "METADATA_COMPILE_UNIT" $ do
     let recordSize = length (recordFields r)
@@ -471,31 +499,25 @@ parseMetadataEntry vt mt pm (fromEntry -> Just r) =
     when (recordSize < 14 || recordSize > 19)
       (fail "Invalid record")
 
-    ctx <- getContext
-    isDistinct             <- parseField r 0 nonzero
-    dicuLanguage           <- parseField r 1 numeric
-    dicuFile               <-
-      mdForwardRefOrNull ctx mt <$> parseField r 2 numeric
-    dicuProducer           <- mdStringOrNull ctx mt <$> parseField r 3 numeric
-    dicuIsOptimized        <- parseField r 4 nonzero
-    dicuFlags              <- mdStringOrNull ctx mt <$> parseField r 5 numeric
-    dicuRuntimeVersion     <- parseField r 6 numeric
-    dicuSplitDebugFilename <- mdStringOrNull ctx mt <$> parseField r 7 numeric
-    dicuEmissionKind       <- parseField r 8 numeric
-    dicuEnums              <-
-      mdForwardRefOrNull ctx mt <$> parseField r 9 numeric
-    dicuRetainedTypes      <-
-      mdForwardRefOrNull ctx mt <$> parseField r 10 numeric
-    dicuSubprograms        <-
-      mdForwardRefOrNull ctx mt <$> parseField r 11 numeric
-    dicuGlobals            <-
-      mdForwardRefOrNull ctx mt <$> parseField r 12 numeric
-    dicuImports            <-
-      mdForwardRefOrNull ctx mt <$> parseField r 13 numeric
-    dicuMacros <-
-      if recordSize <= 15
-      then pure Nothing
-      else mdForwardRefOrNull ctx mt <$> parseField r 15 numeric
+    ctx        <- getContext
+    isDistinct <- parseField r 0 nonzero
+    dicu       <- DICompileUnit
+      <$> parseField r 1 numeric                                  -- dicuLanguage
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r 2 numeric)  -- dicuFile
+      <*> (mdStringOrNull ctx mt     <$> parseField r 3 numeric)  -- dicuProducer
+      <*> parseField r 4 nonzero                                  -- dicuIsOptimized
+      <*> (mdStringOrNull ctx mt     <$> parseField r 5 numeric)  -- dicuFlags
+      <*> parseField r 6 numeric                                  -- dicuRuntimeVersion
+      <*> (mdStringOrNull ctx mt     <$> parseField r 7 numeric)  -- dicuSplitDebugFilename
+      <*> parseField r 8 numeric                                  -- dicuEmissionKind
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r 9 numeric)  -- dicuEnums
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r 10 numeric) -- dicuRetainedTypes
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r 11 numeric) -- dicuSubprograms
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r 12 numeric) -- dicuGlobals
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r 13 numeric) -- dicuImports
+      <*> if recordSize <= 15
+          then pure Nothing
+          else mdForwardRefOrNull ctx mt <$> parseField r 15 numeric -- dicuMacros
     dicuDWOId <-
       if recordSize <= 14
       then pure 0
@@ -504,8 +526,9 @@ parseMetadataEntry vt mt pm (fromEntry -> Just r) =
       if recordSize <= 16
       then pure True
       else parseField r 16 nonzero
+    let dicu' = dicu dicuDWOId dicuSplitDebugInlining
     return $! updateMetadataTable
-      (addDebugInfo isDistinct (DebugInfoCompileUnit DICompileUnit {..})) pm
+      (addDebugInfo isDistinct (DebugInfoCompileUnit dicu')) pm
 
 
   21 -> label "METADATA_SUBPROGRAM" $ do
@@ -519,106 +542,104 @@ parseMetadataEntry vt mt pm (fromEntry -> Just r) =
     unless (18 <= recordSize && recordSize <= 21)
       (fail ("Invalid subprogram record, size = " ++ show recordSize))
 
-    ctx <- getContext
-    isDistinct         <- parseField r 0 nonzero
-    dispScope          <- mdForwardRefOrNull ctx mt <$> parseField r 1 numeric
-    dispName           <- mdStringOrNull ctx mt <$> parseField r 2 numeric
-    dispLinkageName    <- mdStringOrNull ctx mt <$> parseField r 3 numeric
-    dispFile           <- mdForwardRefOrNull ctx mt <$> parseField r 4 numeric
-    dispLine           <- parseField r 5 numeric
-    dispType           <- mdForwardRefOrNull ctx mt <$> parseField r 6 numeric
-    dispIsLocal        <- parseField r 7 nonzero
-    dispIsDefinition   <- parseField r 8 nonzero
-    dispScopeLine      <- parseField r 9 numeric
-    dispContainingType <- mdForwardRefOrNull ctx mt <$> parseField r 10 numeric
-    dispVirtuality     <- parseField r 11 numeric
-    dispVirtualIndex   <- parseField r 12 numeric
-    dispThisAdjustment <- if hasThisAdjustment
-                            then parseField r 19 numeric
-                            else return 0
-    dispThrownTypes <- if hasThrownTypes
-                         then mdForwardRefOrNull ctx mt <$> parseField r 20 numeric
-                         else return Nothing
-    dispFlags          <- parseField r 13 numeric
-    dispIsOptimized    <- parseField r 14 nonzero
-    dispTemplateParams <-
-      mdForwardRefOrNull ctx mt <$> parseField r (adj 15) numeric
-    dispDeclaration <-
-      mdForwardRefOrNull ctx mt <$> parseField r (adj 16) numeric
-    dispVariables <-
-      mdForwardRefOrNull ctx mt <$> parseField r (adj 17) numeric
+    ctx        <- getContext
+    isDistinct <- parseField r 0 nonzero -- isDistinct
+    disp       <- DISubprogram
+      <$> (mdForwardRefOrNull ctx mt <$> parseField r 1 numeric)        -- dispScope
+      <*> (mdStringOrNull ctx mt <$> parseField r 2 numeric)            -- dispName
+      <*> (mdStringOrNull ctx mt <$> parseField r 3 numeric)            -- dispLinkageName
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r 4 numeric)        -- dispFile
+      <*> parseField r 5 numeric                                        -- dispLine
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r 6 numeric)        -- dispType
+      <*> parseField r 7 nonzero                                        -- dispIsLocal
+      <*> parseField r 8 nonzero                                        -- dispIsDefinition
+      <*> parseField r 9 numeric                                        -- dispScopeLine
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r 10 numeric)       -- dispContainingType
+      <*> parseField r 11 numeric                                       -- dispVirtuality
+      <*> parseField r 12 numeric                                       -- dispVirtualIndex
+      <*> (if hasThisAdjustment
+          then parseField r 19 numeric
+          else return 0)                                                -- dispThisAdjustment
+      <*> (if hasThrownTypes
+          then mdForwardRefOrNull ctx mt <$> parseField r 20 numeric
+          else return Nothing)                                          -- dispThrownTypes
+      <*> parseField r 13 numeric                                       -- dispFlags
+      <*> parseField r 14 nonzero                                       -- dispIsOptimized
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r (adj 15) numeric) -- dispTemplateParams
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r (adj 16) numeric) -- dispDeclaration
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r (adj 17) numeric) -- dispVariables
     -- TODO: in the LLVM parser, it then goes into the metadata table
     -- and updates function entries to point to subprograms. Is that
     -- neccessary for us?
     return $! updateMetadataTable
-      (addDebugInfo isDistinct (DebugInfoSubprogram DISubprogram{..})) pm
+      (addDebugInfo isDistinct (DebugInfoSubprogram disp)) pm
 
   22 -> label "METADATA_LEXICAL_BLOCK" $ do
     when (length (recordFields r) /= 5)
       (fail "Invalid record")
     cxt <- getContext
     isDistinct <- parseField r 0 nonzero
-    dilbScope  <- mdForwardRefOrNull cxt mt <$> parseField r 1 numeric
-    dilbFile   <- mdForwardRefOrNull cxt mt <$> parseField r 2 numeric
-    dilbLine   <- parseField r 3 numeric
-    dilbColumn <- parseField r 4 numeric
+    dilb <- DILexicalBlock
+      <$> (mdForwardRefOrNull cxt mt <$> parseField r 1 numeric) -- dilbScope
+      <*> (mdForwardRefOrNull cxt mt <$> parseField r 2 numeric) -- dilbFile
+      <*> parseField r 3 numeric                                 -- dilbLine
+      <*> parseField r 4 numeric                                 -- dilbColumn
     return $! updateMetadataTable
-      (addDebugInfo isDistinct (DebugInfoLexicalBlock DILexicalBlock{..})) pm
+      (addDebugInfo isDistinct (DebugInfoLexicalBlock dilb)) pm
 
   23 -> label "METADATA_LEXICAL_BLOCK_FILE" $ do
     when (length (recordFields r) /= 4)
       (fail "Invalid record")
-    cxt <- getContext
+
+    cxt        <- getContext
     isDistinct <- parseField r 0 nonzero
-    dilbfScope <- do
-      mScope <- mdForwardRefOrNull cxt mt <$> parseField r 1 numeric
-      maybe (fail "Invalid record: scope field not present") return mScope
-    dilbfFile <- mdForwardRefOrNull cxt mt <$> parseField r 2 numeric
-    dilbfDiscriminator <- parseField r 3 numeric
-    return $! updateMetadataTable
-      (addDebugInfo
-         isDistinct
-         (DebugInfoLexicalBlockFile DILexicalBlockFile{..}))
-      pm
+    dilbf      <- getCompose $ DILexicalBlockFile -- Composing (Parse . Maybe)
+      <$$> (mdForwardRefOrNull cxt mt <$> parseField r 1 numeric)
+      <<*> (mdForwardRefOrNull cxt mt <$> parseField r 2 numeric) -- dilbfFile
+      <<*> (parseField r 3 numeric) -- dilbfDiscriminator
+
+    case dilbf of
+      Just dilbf' ->
+        return $! updateMetadataTable
+          (addDebugInfo isDistinct (DebugInfoLexicalBlockFile dilbf')) pm
+      Nothing -> fail "Invalid record: scope field not present"
 
   24 -> label "METADATA_NAMESPACE" $ do
     isNew <- case length (recordFields r) of
                3 -> return True
                5 -> return False
                _ -> fail "Invalid METADATA_NAMESPACE record"
-    cxt <- getContext
+    cxt        <- getContext
     isDistinct <- parseField r 0 nonzero
-    dinsScope <- mdForwardRef cxt mt <$> parseField r 1 numeric
-    dinsFile <- if isNew then (return (ValMdString "")) else mdForwardRef cxt mt <$> parseField r 2 numeric
     let nameIdx = if isNew then 2 else 3
-    dinsName <- mdString cxt mt <$> parseField r nameIdx numeric
-    dinsLine <- if isNew then return 0 else parseField r 4 numeric
+    dins       <- DINameSpace
+      <$> (mdString cxt mt         <$> parseField r nameIdx numeric) -- dinsName
+      <*> (mdForwardRef cxt mt     <$> parseField r 1 numeric)       -- dinsScope
+      <*> (if isNew
+          then return (ValMdString "")
+          else mdForwardRef cxt mt <$> parseField r 2 numeric)       -- dinsFile
+      <*> if isNew then return 0 else parseField r 4 numeric         -- dinsLine
     return $! updateMetadataTable
-        (addDebugInfo
-            isDistinct
-            (DebugInfoNameSpace (DINameSpace {..})))
-        pm
+      (addDebugInfo isDistinct (DebugInfoNameSpace dins)) pm
+
   25 -> label "METADATA_TEMPLATE_TYPE" $ do
     cxt <- getContext
     isDistinct <- parseField r 0 nonzero
-    dittpName <- mdString cxt mt <$> parseField r 1 numeric
-    dittpType <- mdForwardRef cxt mt <$> parseField r 2 numeric
+    dittp <- DITemplateTypeParameter
+      <$> (mdString cxt mt     <$> parseField r 1 numeric) -- dittpName
+      <*> (mdForwardRef cxt mt <$> parseField r 2 numeric) -- dittpType
     return $! updateMetadataTable
-            (addDebugInfo
-                isDistinct
-                (DebugInfoTemplateTypeParameter (DITemplateTypeParameter {..})))
-            pm
+      (addDebugInfo isDistinct (DebugInfoTemplateTypeParameter dittp)) pm
+
   26 -> label "METADATA_TEMPLATE_VALUE" $ do
     cxt <- getContext
     isDistinct <- parseField r 0 nonzero
-    ditvpName  <- mdString cxt mt <$> parseField r 1 numeric
-    ditvpType  <- mdForwardRef cxt mt <$> parseField r 2 numeric
-    ditvpValue <- mdForwardRef cxt mt <$> parseField r 3 numeric
+    ditvp <- DITemplateValueParameter
+      <$> (mdString cxt mt     <$> parseField r 1 numeric) -- ditvpName
+      <*> (mdForwardRef cxt mt <$> parseField r 2 numeric) -- ditvpType
+      <*> (mdForwardRef cxt mt <$> parseField r 3 numeric) -- ditvpValue
     return $! updateMetadataTable
-            (addDebugInfo
-                isDistinct
-                (DebugInfoTemplateValueParameter (DITemplateValueParameter {..})))
-            pm
+      (addDebugInfo isDistinct (DebugInfoTemplateValueParameter ditvp)) pm
 
   27 -> label "METADATA_GLOBAL_VAR" $ do
     let len = length (recordFields r)
@@ -630,22 +651,22 @@ parseMetadataEntry vt mt pm (fromEntry -> Just r) =
     let isDistinct = testBit field0 0
         _version   = shiftR  field0 1 :: Int
 
-    digvScope  <- mdForwardRefOrNull ctx mt <$> parseField r 1 numeric
-    digvName   <- mdStringOrNull ctx mt <$> parseField r 2 numeric
-    digvLinkageName <- mdStringOrNull ctx mt <$> parseField r 3 numeric
-    digvFile   <- mdForwardRefOrNull ctx mt <$> parseField r 4 numeric
-    digvLine   <- parseField r 5 numeric
-    digvType   <- mdForwardRefOrNull ctx mt <$> parseField r 6 numeric
-    digvIsLocal <- parseField r 7 nonzero
-    digvIsDefinition <- parseField r 8 nonzero
-    digvVariable <- mdForwardRefOrNull ctx mt <$> parseField r 9 numeric
-    digvDeclaration <- mdForwardRefOrNull ctx mt <$> parseField r 10 numeric
-    digvAlignment   <- if len > 11 then Just <$> parseField r 11 numeric
-                                   else return Nothing
+    digv <- DIGlobalVariable
+      <$> (mdForwardRefOrNull ctx mt <$> parseField r 1 numeric)  -- digvScope
+      <*> (mdStringOrNull ctx mt     <$> parseField r 2 numeric)  -- digvName
+      <*> (mdStringOrNull ctx mt     <$> parseField r 3 numeric)  -- digvLinkageName
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r 4 numeric)  -- digvFile
+      <*> parseField r 5 numeric                                  -- digvLine
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r 6 numeric)  -- digvType
+      <*> parseField r 7 nonzero                                  -- digvIsLocal
+      <*> parseField r 8 nonzero                                  -- digvIsDefinition
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r 9 numeric)  -- digvVariable
+      <*> (mdForwardRefOrNull ctx mt <$> parseField r 10 numeric) -- digvDeclaration
+      <*> if len > 11
+          then Just                  <$> parseField r 11 numeric  -- digvAlignment
+          else pure Nothing
     return $! updateMetadataTable
-      (addDebugInfo
-         isDistinct
-         (DebugInfoGlobalVariable DIGlobalVariable{..})) pm
+      (addDebugInfo isDistinct (DebugInfoGlobalVariable digv)) pm
 
   28 -> label "METADATA_LOCAL_VAR" $ do
     -- this one is a bit funky:
@@ -674,41 +695,45 @@ parseMetadataEntry vt mt pm (fromEntry -> Just r) =
 
          else return 0
 
-    dilvScope  <- mdForwardRefOrNull ("dilvScope":ctx) mt <$> parseField r (adj 1) numeric
-    dilvName   <- mdStringOrNull     ("dilvName" :ctx) mt <$> parseField r (adj 2) numeric
-    dilvFile   <- mdForwardRefOrNull ("dilvFile" :ctx) mt <$> parseField r (adj 3) numeric
-    dilvLine   <- parseField r (adj 4) numeric
-    dilvType   <- mdForwardRefOrNull ("dilvType" :ctx) mt <$> parseField r (adj 5) numeric
-    dilvArg    <- parseField r (adj 6) numeric
-    dilvFlags  <- parseField r (adj 7) numeric
+    dilv <- DILocalVariable
+      <$> (mdForwardRefOrNull ("dilvScope":ctx) mt
+            <$> parseField r (adj 1) numeric) -- dilvScope
+      <*> (mdStringOrNull     ("dilvName" :ctx) mt
+            <$> parseField r (adj 2) numeric) -- dilvName
+      <*> (mdForwardRefOrNull ("dilvFile" :ctx) mt
+            <$> parseField r (adj 3) numeric) -- dilvFile
+      <*> parseField r (adj 4) numeric        -- dilvLine
+      <*> (mdForwardRefOrNull ("dilvType" :ctx) mt
+            <$> parseField r (adj 5) numeric) -- dilvType
+      <*> parseField r (adj 6) numeric        -- dilvArg
+      <*> parseField r (adj 7) numeric        -- dilvFlags
     return $! updateMetadataTable
-      (addDebugInfo isDistinct (DebugInfoLocalVariable DILocalVariable{..})) pm
+      (addDebugInfo isDistinct (DebugInfoLocalVariable dilv)) pm
 
   29 -> label "METADATA_EXPRESSION" $ do
     let recordSize = length (recordFields r)
     when (recordSize < 1)
       (fail "Invalid record")
     isDistinct <- parseField r 0 nonzero
-    dieElements <- parseFields r 1 numeric
-    return $! updateMetadataTable
-      (addDebugInfo isDistinct (DebugInfoExpression DIExpression{..})) pm
+    diExpr     <- DebugInfoExpression . DIExpression <$> parseFields r 1 numeric
+    return $! updateMetadataTable (addDebugInfo isDistinct diExpr) pm
 
   30 -> label "METADATA_OBJC_PROPERTY" $ do
     -- TODO
     fail "not yet implemented"
   31 -> label "METADATA_IMPORTED_ENTITY" $ do
-    cxt <- getContext
+    cxt        <- getContext
     isDistinct <- parseField r 0 nonzero
-    diieTag    <- parseField r 1 numeric
-    diieScope  <- mdForwardRefOrNull cxt mt <$> parseField r 2 numeric
-    diieEntity <- mdForwardRefOrNull cxt mt <$> parseField r 3 numeric
-    diieLine   <- parseField r 4 numeric
-    diieName   <- mdString cxt mt <$> parseField r 5 numeric
+    diie       <- DIImportedEntity
+      <$> parseField r 1 numeric                                 -- diieTag
+      <*> (mdString cxt mt           <$> parseField r 5 numeric) -- diieName
+      <*> (mdForwardRefOrNull cxt mt <$> parseField r 2 numeric) -- diieScope
+      <*> (mdForwardRefOrNull cxt mt <$> parseField r 3 numeric) -- diieEntity
+      <*> parseField r 4 numeric                                 -- diieLine
+
     return $! updateMetadataTable
-        (addDebugInfo
-            isDistinct
-            (DebugInfoImportedEntity (DIImportedEntity {..})))
-        pm
+      (addDebugInfo isDistinct (DebugInfoImportedEntity diie)) pm
+
   32 -> label "METADATA_MODULE" $ do
     -- cxt <- getContext
     -- isDistinct <- parseField r 0 numeric
@@ -753,7 +778,7 @@ parseMetadataEntry vt mt pm (fromEntry -> Just r) =
       (fail "Invalid record: metadata strings truncated")
     let strings = snd (mapAccumL f bsStrings lengths)
           where f s i = case S.splitAt i s of
-                          (str,rest) -> (rest, Char8.unpack str)
+                          (str, rest) -> (rest, Char8.unpack str)
     return $! updateMetadataTable (addStrings strings) pm
 
   -- [ valueid, n x [id, mdnode] ]
@@ -777,10 +802,11 @@ parseMetadataEntry vt mt pm (fromEntry -> Just r) =
       (fail "Invalid record: unsupported layout")
     cxt <- getContext
     isDistinct      <- parseField r 0 nonzero
-    digveVariable   <- mdForwardRefOrNull cxt mt <$> parseField r 1 numeric
-    digveExpression <- mdForwardRefOrNull cxt mt <$> parseField r 2 numeric
+    digve <- DIGlobalVariableExpression
+      <$> (mdForwardRefOrNull cxt mt <$> parseField r 1 numeric) -- digveVariable
+      <*> (mdForwardRefOrNull cxt mt <$> parseField r 2 numeric) -- digveExpression
     return $! updateMetadataTable
-      (addDebugInfo isDistinct (DebugInfoGlobalVariableExpression DIGlobalVariableExpression{..})) pm
+      (addDebugInfo isDistinct (DebugInfoGlobalVariableExpression digve)) pm
 
   38 -> label "METADATA_INDEX_OFFSET" $ do
 


### PR DESCRIPTION
I have a few changes to metadata parsing coming through, this is the first.  

There are many reasons to do this. A few:

 - Obviousness: We should clearly separate context-free from context-sensitive parsing when possible
 - Performance: Applicative code is guaranteed to have the same "effects", regardless of the results of previous computations in the chain. It is therefore subject to further optimization
 - Compositionality: Applicative functors compose, monads don't (in general). This is the one I actually need for further work.