### PR TITLE
Remove outdated TODO about DILocation/MDLocation in LLVM 3.7+

### DIFF
--- a/src/Data/LLVM/BitCode/IR/Metadata.hs
+++ b/src/Data/LLVM/BitCode/IR/Metadata.hs
@@ -355,9 +355,6 @@ parseMetadataEntry vt mt pm (fromEntry -> Just r) =
 
   -- [distinct, line, col, scope, inlined-at?]
   7 -> label "METADATA_LOCATION" $ do
-    -- TODO: broken in 3.7+; needs to be a DILocation rather than an
-    -- MDLocation, but there appears to be no difference in the
-    -- bitcode. /sigh/
     let field = parseField r
     cxt        <- getContext
     isDistinct <- field 0 nonzero


### PR DESCRIPTION
It appears this has been fixed in llvm-pretty:
- https://github.com/elliottt/llvm-pretty/blob/47aace66cdc5abc2294918b9665ef14b4d22762e/src/Text/LLVM/PP.hs#L46
- https://github.com/elliottt/llvm-pretty/commit/53773a3c34a87d3675994e1fe2c3cbd205c7d30a

Original commit: https://github.com/GaloisInc/llvm-pretty-bc-parser/commit/0f23af51c0df0e55afcce8a32ec8db49face966a

Does this seem right @TomMD @acfoltzer ?