### PR TITLE
Enable parsing of source_filename

### DIFF
--- a/llvm-pretty-bc-parser.cabal
+++ b/llvm-pretty-bc-parser.cabal
@@ -58,7 +58,7 @@ Library
                        cereal     >= 0.3.5.2,
                        bytestring >= 0.9.1,
                        utf8-string>= 1.0,
-                       llvm-pretty>= 0.7.3
+                       llvm-pretty>= 0.7.4
 
 Executable llvm-disasm
   Main-is:             LLVMDis.hs
@@ -74,7 +74,7 @@ Executable llvm-disasm
                        fgl        >= 5.5,
                        fgl-visualize >= 0.1,
                        cereal     >= 0.3.5.2,
-                       llvm-pretty>= 0.7.3,
+                       llvm-pretty>= 0.7.4,
                        pretty-show>= 1.6,
                        llvm-pretty-bc-parser
 
@@ -89,7 +89,7 @@ Test-suite disasm-test
                        directory,
                        bytestring,
                        filepath,
-                       llvm-pretty>= 0.7.3,
+                       llvm-pretty>= 0.7.4,
                        llvm-pretty-bc-parser
 
 Executable regression-test
@@ -102,7 +102,7 @@ Executable regression-test
                        filepath,
                        text,
                        turtle,
-                       llvm-pretty>= 0.7.3,
+                       llvm-pretty>= 0.7.4,
                        llvm-pretty-bc-parser
 
 Executable fuzz-llvm-disasm
@@ -124,7 +124,7 @@ Executable fuzz-llvm-disasm
                        abstract-par,
                        monad-par,
                        transformers,
-                       llvm-pretty>= 0.7.3,
+                       llvm-pretty>= 0.7.4,
                        llvm-pretty-bc-parser
   if flag(fuzz)
       Buildable:       True

--- a/src/Data/LLVM/BitCode/IR/Module.hs
+++ b/src/Data/LLVM/BitCode/IR/Module.hs
@@ -74,7 +74,8 @@ finalizeModule pm = label "finalizeModule" $ do
   let lkp = lookupBlockName (partialDefines pm)
   defines <- T.mapM (finalizePartialDefine lkp) (partialDefines pm)
   return emptyModule
-    { modDataLayout = partialDataLayout pm
+    { modSourceName = partialSourceName pm
+    , modDataLayout = partialDataLayout pm
     , modNamedMd    = partialNamedMd pm
     , modUnnamedMd  = sortBy (comparing umIndex) unnamed
     , modGlobals    = F.toList globals


### PR DESCRIPTION
We already parse this string, but it wasn't previously added to the final `Module`. 

Doesn't strictly depend on v0.7.4 of `llvm-pretty` (https://github.com/elliottt/llvm-pretty/pull/35), but won't do much without it. 

Fixes #74 