### PR TITLE
Deduplication of metadata

### DIFF
--- a/doc/developing.md
+++ b/doc/developing.md
@@ -7,7 +7,12 @@
     - [Upstream documentation](#upstream-documentation)
     - [Running the tests](#running-the-tests)
         - [`llvm-disasm-test`](#llvm-disasm-test)
+            - [description](#description)
+            - [use](#use)
         - [`regression-test`](#regression-test)
+        - [`unit-test`](#unit-test)
+    - [Travis CI build](#travis-ci-build)
+
 <!-- markdown-toc end -->
 
 ## Upstream documentation
@@ -78,10 +83,14 @@ To see all the options,
 ./dist/build/regression-test/regression-test --help
 ```
 
+### `unit-test`
+
+These are run with `cabal test` or `cabal new-test`.
+
 ## Travis CI build
 
-**Note**: the CI build only makes sure the project compiles, it doesn't run any
-meaningful tests.
+**Note**: the CI build doesn't run the full test suite, just some regression
+tests and the unit tests.
 
 The `.travis.yml` file is generated using
 [haskell-ci](https://github.com/haskell-CI/haskell-ci). However, we add the 

--- a/llvm-pretty-bc-parser.cabal
+++ b/llvm-pretty-bc-parser.cabal
@@ -27,7 +27,9 @@ Source-repository head
 Library
   Hs-source-dirs:      src
   Exposed-modules:     Data.LLVM.CFG,
-                       Data.LLVM.BitCode
+                       Data.LLVM.BitCode,
+                       -- for testing:
+                       Data.LLVM.Internal
 
   Default-language:    Haskell2010
 
@@ -59,6 +61,7 @@ Library
                        cereal     >= 0.3.5.2,
                        bytestring >= 0.9.1,
                        utf8-string>= 1.0,
+                       uniplate   >= 1.6,
                        llvm-pretty>= 0.7.4
 
 Executable llvm-disasm
@@ -78,6 +81,27 @@ Executable llvm-disasm
                        llvm-pretty>= 0.7.4,
                        pretty-show>= 1.6,
                        llvm-pretty-bc-parser
+
+test-suite unit-test
+    type:                exitcode-stdio-1.0
+    main-is:             Main.hs
+    other-modules:       Tests.Instances,
+                         Tests.Metadata
+    hs-source-dirs:      unit-test
+    default-language:    Haskell2010
+    ghc-options:         -W -Wcompat
+                         -Wunrecognised-warning-flags
+                         -threaded
+    -- other-extensions:    OverloadedStrings, ...
+    build-depends: base -any,
+                   HUnit -any,
+                   QuickCheck -any,
+                   generic-random -any,
+                   tasty -any,
+                   tasty-hunit -any,
+                   tasty-quickcheck -any,
+                   llvm-pretty -any,
+                   llvm-pretty-bc-parser
 
 Test-suite disasm-test
   type:                exitcode-stdio-1.0

--- a/src/Data/LLVM/BitCode/IR/Module.hs
+++ b/src/Data/LLVM/BitCode/IR/Module.hs
@@ -69,7 +69,7 @@ finalizeModule pm = label "finalizeModule" $ do
   globals  <- T.mapM finalizeGlobal       (partialGlobals pm)
   declares <- T.mapM finalizeDeclare      (partialDeclares pm)
   aliases  <- T.mapM finalizePartialAlias (partialAliases pm)
-  unnamed  <- T.mapM finalizePartialUnnamedMd (partialUnnamedMd pm)
+  unnamed  <- T.mapM finalizePartialUnnamedMd (dedupMetadata (partialUnnamedMd pm))
   types    <- resolveTypeDecls
   let lkp = lookupBlockName (partialDefines pm)
   defines <- T.mapM (finalizePartialDefine lkp) (partialDefines pm)

--- a/src/Data/LLVM/Internal.hs
+++ b/src/Data/LLVM/Internal.hs
@@ -1,0 +1,6 @@
+-- | This module exports some internal modules *for use in testing only*.
+module Data.LLVM.Internal
+  ( module Data.LLVM.BitCode.IR.Metadata
+  ) where
+
+import Data.LLVM.BitCode.IR.Metadata

--- a/unit-test/Main.hs
+++ b/unit-test/Main.hs
@@ -1,0 +1,8 @@
+module Main (main) where
+
+import qualified Test.Tasty as T
+import qualified Tests.Metadata
+
+main :: IO ()
+main = T.defaultMain $ T.testGroup "Tests" [ Tests.Metadata.tests
+                                           ]

--- a/unit-test/Tests/Instances.hs
+++ b/unit-test/Tests/Instances.hs
@@ -1,0 +1,80 @@
+-- | Arbitrary instances for LLVM AST nodes, for QuickCheck.
+--
+-- This module takes a long time to compile... small price to pay for not
+-- writing instances.
+module Tests.Instances where
+
+import Generic.Random hiding ((%))
+import Test.QuickCheck.Arbitrary (Arbitrary(..))
+
+import Data.LLVM.Internal
+import Text.LLVM.AST
+
+-------------------------------------------------------------------------
+-- ** llvm-pretty
+
+instance Arbitrary Module                                             where arbitrary = genericArbitrary uniform
+instance Arbitrary NamedMd                                            where arbitrary = genericArbitrary uniform
+instance Arbitrary UnnamedMd                                          where arbitrary = genericArbitrary uniform
+instance Arbitrary GlobalAlias                                        where arbitrary = genericArbitrary uniform
+instance Arbitrary LayoutSpec                                         where arbitrary = genericArbitrary uniform
+instance Arbitrary Mangling                                           where arbitrary = genericArbitrary uniform
+instance Arbitrary SelectionKind                                      where arbitrary = genericArbitrary uniform
+instance Arbitrary PrimType                                           where arbitrary = genericArbitrary uniform
+instance Arbitrary FloatType                                          where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (Type' lab)                       where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (NullResult lab)                  where arbitrary = genericArbitrary uniform
+instance Arbitrary TypeDecl                                           where arbitrary = genericArbitrary uniform
+instance Arbitrary Global                                             where arbitrary = genericArbitrary uniform
+instance Arbitrary GlobalAttrs                                        where arbitrary = genericArbitrary uniform
+instance Arbitrary Declare                                            where arbitrary = genericArbitrary uniform
+instance Arbitrary Define                                             where arbitrary = genericArbitrary uniform
+instance Arbitrary FunAttr                                            where arbitrary = genericArbitrary uniform
+instance Arbitrary BlockLabel                                         where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (BasicBlock' lab)                 where arbitrary = genericArbitrary uniform
+instance Arbitrary Linkage                                            where arbitrary = genericArbitrary uniform
+instance Arbitrary Visibility                                         where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (Typed lab)                       where arbitrary = genericArbitrary uniform
+instance Arbitrary ArithOp                                            where arbitrary = genericArbitrary uniform
+instance Arbitrary BitOp                                              where arbitrary = genericArbitrary uniform
+instance Arbitrary ConvOp                                             where arbitrary = genericArbitrary uniform
+instance Arbitrary AtomicRWOp                                         where arbitrary = genericArbitrary uniform
+instance Arbitrary AtomicOrdering                                     where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (Instr' lab)                      where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (Clause' lab)                     where arbitrary = genericArbitrary uniform
+instance Arbitrary ICmpOp                                             where arbitrary = genericArbitrary uniform
+instance Arbitrary FCmpOp                                             where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (Value' lab)                      where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (ValMd' lab)                      where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DebugLoc' lab)                   where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (Stmt' lab)                       where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (ConstExpr' lab)                  where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DebugInfo' lab)                  where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DIImportedEntity' lab)           where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DITemplateTypeParameter' lab)    where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DITemplateValueParameter' lab)   where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DINameSpace' lab)                where arbitrary = genericArbitrary uniform
+instance Arbitrary DIBasicType                                        where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DICompileUnit' lab)              where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DICompositeType' lab)            where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DIDerivedType' lab)              where arbitrary = genericArbitrary uniform
+instance Arbitrary DIExpression                                       where arbitrary = genericArbitrary uniform
+instance Arbitrary DIFile                                             where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DIGlobalVariable' lab)           where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DIGlobalVariableExpression' lab) where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DILexicalBlock' lab)             where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DILexicalBlockFile' lab)         where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DILocalVariable' lab)            where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DISubprogram' lab)               where arbitrary = genericArbitrary uniform
+instance Arbitrary DISubrange                                         where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DISubroutineType' lab)           where arbitrary = genericArbitrary uniform
+
+-- Newtypes
+instance Arbitrary Ident  where arbitrary = genericArbitrary uniform
+instance Arbitrary Symbol where arbitrary = genericArbitrary uniform
+instance Arbitrary GC     where arbitrary = genericArbitrary uniform
+
+-------------------------------------------------------------------------
+-- ** llvm-pretty-bc-parser
+
+instance Arbitrary PartialUnnamedMd where arbitrary = genericArbitrary uniform

--- a/unit-test/Tests/Metadata.hs
+++ b/unit-test/Tests/Metadata.hs
@@ -1,0 +1,45 @@
+module Tests.Metadata (tests) where
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@?=))
+import Test.Tasty.QuickCheck (testProperty)
+import Test.QuickCheck ((==>))
+
+import Data.LLVM.Internal
+import Text.LLVM.AST
+
+import Tests.Instances()
+
+tests :: TestTree
+tests = testGroup "Metadata" $
+    [ testCase "test dedup metadata" $
+        [] @?= dedupMetadata []
+
+    -- The first two should remain unchanged, but the third duplicates information in
+    -- the second, so should be updated to hold a reference to it.
+    , testGroup "test dedup metadata" $
+        let mkPum i v = PartialUnnamedMd i v True
+            val1 = mkPum 1 (ValMdString "str")
+            val2 = mkPum 2 (ValMdDebugInfo (DebugInfoExpression (DIExpression [])))
+            val3 = mkPum 3 (ValMdNode [Just (pumValues val2)])
+        in [ testCase "1" $
+               val1 @?= dedupMetadata [val1, val2, val3] !! 0
+           , testCase "2" $
+               val2 @?= dedupMetadata [val1, val2, val3] !! 1
+           , testCase "3" $
+               mkPum 3 (ValMdNode [Just (ValMdRef 2)]) @?=
+                  dedupMetadata [val1, val2, val3] !! 2
+           ]
+
+    -- Deduplication should not changes: references or strings
+    -- This test takes too long.
+    -- , testProperty "dedup metadata" $
+    --     \lst i -> i >= 0 && length lst > i ==>
+    --       let result = dedupMetadata lst
+    --       in if lst !! i /= result !! i
+    --          then case pumValues (result !! i) of
+    --                 ValMdRef _    -> False
+    --                 ValMdString _ -> False
+    --                 _             -> True
+    --          else True
+    ]


### PR DESCRIPTION
See the included comment for the rationale. Essentially, the way forward references happen is not lazy enough, some references are inlined unnecessarily. 

This behavior blocks solving https://github.com/elliottt/llvm-pretty/issues/47 by always including `distinct` before a `DICompileUnit`, because this can't be done when the `DICompileUnit` is inlined. 