### PR TITLE
Unify assertion infrastructure

### DIFF
--- a/llvm-pretty-bc-parser.cabal
+++ b/llvm-pretty-bc-parser.cabal
@@ -33,7 +33,8 @@ Library
 
   Default-language:    Haskell2010
 
-  Other-modules:       Data.LLVM.BitCode.BitString,
+  Other-modules:       Data.LLVM.BitCode.Assert,
+                       Data.LLVM.BitCode.BitString,
                        Data.LLVM.BitCode.Bitstream,
                        Data.LLVM.BitCode.GetBits,
                        Data.LLVM.BitCode.IR,

--- a/src/Data/LLVM/BitCode/Assert.hs
+++ b/src/Data/LLVM/BitCode/Assert.hs
@@ -1,0 +1,62 @@
+{- |
+Module      : Data.LLVM.BitCode.Assert
+Description : This module implements exceptions and warnings about bitcode.
+License     : BSD3
+Maintainer  : lbarrett
+Stability   : experimental
+
+This module is meant to be imported qualified as @Assert@
+
+-}
+
+module Data.LLVM.BitCode.Assert
+  ( failWithMsg
+  , unknownEntity
+  , recordSizeLess
+  , recordSizeGreater
+  , recordSizeBetween
+  , recordSizeIn
+  ) where
+
+import qualified Data.LLVM.BitCode.Record as Record
+import           Data.LLVM.BitCode.Record (Record)
+import           Control.Monad (when)
+import           Control.Monad.Fail (MonadFail)
+
+supportedCompilerMessage :: [String]
+supportedCompilerMessage =
+  [ "Are you sure you're using a supported compiler?"
+  , "Check here: https://github.com/GaloisInc/llvm-pretty-bc-parser"
+  ]
+
+-- | Call 'fail' with a helpful hint to the user
+failWithMsg :: MonadFail m => String -> m a
+failWithMsg s = fail $ unlines (s:supportedCompilerMessage)
+
+-- | For when an unknown value of an enumeration is encountered
+unknownEntity :: (MonadFail m, Show a) => String -> a -> m b
+unknownEntity sort val = failWithMsg ("Unknown " ++ sort ++ " " ++ show val)
+
+recordSizeCmp :: MonadFail m => String -> (Int -> Bool) -> Record -> m ()
+recordSizeCmp msg compare_ record =
+  let len = length (Record.recordFields record)
+  in when (compare_ len) $ failWithMsg $ unlines $
+       [ "Invalid record size: " ++ show len, msg ]
+
+recordSizeLess :: MonadFail m => Record -> Int -> m ()
+recordSizeLess r i = recordSizeCmp "Expected size less than" (i <=) r
+
+recordSizeGreater :: MonadFail m => Record -> Int -> m ()
+recordSizeGreater r i = recordSizeCmp "Expected size greater than" (<= i) r
+
+recordSizeBetween :: MonadFail m => Record -> Int -> Int -> m ()
+recordSizeBetween record lb ub =
+  recordSizeGreater record lb >> recordSizeLess record ub
+
+recordSizeIn :: MonadFail m => Record -> [Int] -> m ()
+recordSizeIn record ns =
+  let len = length (Record.recordFields record)
+  in when (not (len `elem` ns)) $ failWithMsg $ unlines $
+       [ "Invalid record size: " ++ show len
+       , "Expected one of: " ++ show ns
+       ]

--- a/src/Data/LLVM/BitCode/IR/Types.hs
+++ b/src/Data/LLVM/BitCode/IR/Types.hs
@@ -5,18 +5,19 @@ module Data.LLVM.BitCode.IR.Types (
   , parseTypeBlock
   ) where
 
-import Data.LLVM.BitCode.Bitstream
-import Data.LLVM.BitCode.Match
-import Data.LLVM.BitCode.Parse
-import Data.LLVM.BitCode.Record
-import Text.LLVM.AST
+import qualified Data.LLVM.BitCode.Assert as Assert
+import           Data.LLVM.BitCode.Bitstream
+import           Data.LLVM.BitCode.Match
+import           Data.LLVM.BitCode.Parse
+import           Data.LLVM.BitCode.Record
+import           Text.LLVM.AST
 
 import qualified Codec.Binary.UTF8.String as UTF8 (decode)
-import Control.Monad (when,unless,mplus,(<=<))
-import Data.List (sortBy)
-import Data.Maybe (catMaybes)
-import Data.Ord (comparing)
+import           Control.Monad (when,unless,mplus,(<=<))
+import           Data.List (sortBy)
 import qualified Data.Map as Map
+import           Data.Maybe (catMaybes)
+import           Data.Ord (comparing)
 
 
 -- Type Block ------------------------------------------------------------------
@@ -188,7 +189,7 @@ parseTypeBlockEntry (fromEntry -> Just r) = case recordCode r of
       rty:ptys -> addType (FunTy rty ptys vararg)
       []       -> fail "function expects a return type"
 
-  code -> fail ("unknown type code " ++ show code)
+  code -> Assert.unknownEntity "type code " code
 
 -- skip blocks
 parseTypeBlockEntry (block -> Just _) =

--- a/src/Data/LLVM/BitCode/Parse.hs
+++ b/src/Data/LLVM/BitCode/Parse.hs
@@ -8,24 +8,26 @@
 
 module Data.LLVM.BitCode.Parse where
 
-import Text.LLVM.AST
-import Text.LLVM.PP
+import           Text.LLVM.AST
+import           Text.LLVM.PP
 
-import Control.Applicative (Alternative(..))
-import Control.Monad.Fix (MonadFix)
-import Data.Maybe (fromMaybe)
-import Data.Semigroup
-import Data.Typeable (Typeable)
-import Data.Word ( Word32 )
-import MonadLib
+import           Control.Applicative (Alternative(..))
+import           Control.Monad.Fix (MonadFix)
+import           Control.Monad.Fail (MonadFail)
+import qualified Control.Monad.Fail -- makes fail visible for instance
+import           Data.Maybe (fromMaybe)
+import           Data.Semigroup
+import           Data.Typeable (Typeable)
+import           Data.Word ( Word32 )
+import           MonadLib
 import qualified Codec.Binary.UTF8.String as UTF8 (decode)
 import qualified Control.Exception as X
 import qualified Data.ByteString as BS
 import qualified Data.Map as Map
 import qualified Data.Sequence as Seq
-import GHC.Stack (HasCallStack, CallStack, callStack, prettyCallStack)
+import           GHC.Stack (HasCallStack, CallStack, callStack, prettyCallStack)
 
-import Prelude
+import           Prelude
 
 
 -- Error Collection Parser -----------------------------------------------------
@@ -55,6 +57,9 @@ instance Monad Parse where
   Parse m >>= f = Parse (m >>= unParse . f)
 
   {-# INLINE fail #-}
+  fail = failWithContext
+
+instance MonadFail Parse where
   fail = failWithContext
 
 instance Alternative Parse where


### PR DESCRIPTION
Adds an additional "Assert" module which fails with a helpful message when a
user is suspected of using an unsupported compiler.

If a record has semantically meaningful but ignored additional fields, it
can cause a soundness bug in the SAW/Crucible suite. Even the assertions
on non-semantically-important records might catch such bugs, just by
notifying the user that the developers of this project haven't looked at
that compiler yet.

Also:
 - Create a MonadFail instance for Parse
 - Add assertions to Function.hs about record lengths
 - Organize some imports

This will enable the implementation of #107, since these will all be in once place.

Jenkins: https://build.galois.com/view/SAW/job/langston-llvm-disasm-quick-fuzz-branch/44/