### PR TITLE
Add flag to enable the regressions tool build.

### DIFF
--- a/llvm-pretty-bc-parser.cabal
+++ b/llvm-pretty-bc-parser.cabal
@@ -20,6 +20,10 @@ Flag fuzz
   Description:         Enable fuzzing harness
   Default:             False
 
+Flag regressions
+  Description:         Enable regression testing build
+  Default:             False
+
 Source-repository head
   type:                git
   location:            http://github.com/galoisinc/llvm-pretty-bc-parser
@@ -133,6 +137,10 @@ Executable regression-test
                        turtle,
                        llvm-pretty== 0.10.*,
                        llvm-pretty-bc-parser
+  if flag(regressions)
+      Buildable:       True
+  else
+      Buildable:       False
 
 Executable fuzz-llvm-disasm
   Main-is:             Main.hs


### PR DESCRIPTION
This allows the build without some (currently) problematic
dependencies... notably turtle which uses system-fileio, but the
latter is deprecated and has an upper bound on chell that blocks
builds.