### PR TITLE
Performance: MonadLib -> MTL, Map Int -> IntMap

### DIFF
--- a/llvm-pretty-bc-parser.cabal
+++ b/llvm-pretty-bc-parser.cabal
@@ -61,7 +61,7 @@ Library
                        containers >= 0.4,
                        array      >= 0.3,
                        pretty     >= 1.0.1,
-                       monadLib   >= 3.7.2,
+                       mtl        >= 2.2.2,
                        fgl        >= 5.5,
                        cereal     >= 0.3.5.2,
                        bytestring >= 0.9.1,

--- a/src/Data/LLVM/BitCode/IR/Function.hs
+++ b/src/Data/LLVM/BitCode/IR/Function.hs
@@ -343,7 +343,7 @@ parseFunctionBlock unnamedGlobals ents =
         vt  <- getValueTable
 
     -- merge the symbol table with the anonymous symbol table
-    return pd' { partialSymtab = partialSymtab pd' <> symtab }
+    return pd' { partialSymtab = partialSymtab pd' `mappend` symtab }
 
 -- | Parse the members of the function block
 parseFunctionBlockEntry ::

--- a/src/Data/LLVM/BitCode/IR/Globals.hs
+++ b/src/Data/LLVM/BitCode/IR/Globals.hs
@@ -79,11 +79,11 @@ parseGlobalVar n r = label "GLOBALVAR" $ do
 
 finalizeGlobal :: PartialGlobal -> Parse Global
 finalizeGlobal pg = case pgValueIx pg of
-  Nothing -> mkGlobal Nothing
+  Nothing -> liftFinalize $ mkGlobal Nothing
   Just ix -> do
     tv <- getFnValueById (pgType pg) (fromIntegral ix)
-    val <- relabel (const requireBbEntryName) (typedValue tv)
-    mkGlobal (Just val)
+    val <- liftFinalize $ relabel (const requireBbEntryName) (typedValue tv)
+    liftFinalize $ mkGlobal (Just val)
   where
   mkGlobal mval =
     do md <- mapM (relabel (const requireBbEntryName)) (pgMd pg)

--- a/src/Data/LLVM/BitCode/IR/Metadata.hs
+++ b/src/Data/LLVM/BitCode/IR/Metadata.hs
@@ -39,6 +39,7 @@ import qualified Data.ByteString.Char8 as Char8 (unpack)
 import           Data.Either (partitionEithers)
 import           Data.Functor.Compose (Compose(..), getCompose)
 import           Data.Generics.Uniplate.Data
+import qualified Data.IntMap as IntMap
 import           Data.List (mapAccumL, foldl')
 import           Data.Map (Map)
 import qualified Data.Map as Map
@@ -55,7 +56,7 @@ import           GHC.Stack (HasCallStack, callStack)
 data MetadataTable = MetadataTable
   { mtEntries   :: MdTable
   , mtNextNode  :: !Int
-  , mtNodes     :: Map.Map Int (Bool,Bool,Int)
+  , mtNodes     :: IntMap.IntMap (Bool, Bool, Int)
                    -- ^ The entries in the map are: is the entry function local,
                    -- is the entry distinct, and the implicit id for the node.
   } deriving (Show)
@@ -66,7 +67,7 @@ emptyMetadataTable ::
 emptyMetadataTable globals es = MetadataTable
   { mtEntries   = es
   , mtNextNode  = globals
-  , mtNodes     = Map.empty
+  , mtNodes     = IntMap.empty
   }
 
 metadata :: PValMd -> Typed PValue
@@ -87,7 +88,7 @@ addMdValue tv mt = mt { mtEntries = addValue tv' (mtEntries mt) }
 
 nameNode :: Bool -> Bool -> Int -> MetadataTable -> MetadataTable
 nameNode fnLocal isDistinct ix mt = mt
-  { mtNodes    = Map.insert ix (fnLocal,isDistinct,mtNextNode mt) (mtNodes mt)
+  { mtNodes    = IntMap.insert ix (fnLocal,isDistinct,mtNextNode mt) (mtNodes mt)
   , mtNextNode = mtNextNode mt + 1
   }
 
@@ -129,7 +130,7 @@ addOldNode fnLocal vals mt = nameNode fnLocal False ix mt'
 mdForwardRef :: [String] -> MetadataTable -> Int -> PValMd
 mdForwardRef cxt mt ix = fromMaybe fallback nodeRef
   where
-  nodeRef           = reference `fmap` Map.lookup ix (mtNodes mt)
+  nodeRef           = reference `fmap` IntMap.lookup ix (mtNodes mt)
   fallback          = case forwardRef cxt ix (mtEntries mt) of
                         Typed { typedValue = ValMd md } -> md
                         tv                              -> ValMdValue tv
@@ -144,7 +145,7 @@ mdForwardRefOrNull cxt mt ix | ix > 0 = Just (mdForwardRef cxt mt (ix - 1))
 
 mdNodeRef :: HasCallStack
           => [String] -> MetadataTable -> Int -> Int
-mdNodeRef cxt mt ix = maybe except prj (Map.lookup ix (mtNodes mt))
+mdNodeRef cxt mt ix = maybe except prj (IntMap.lookup ix (mtNodes mt))
   where explanation   = "Bad forward reference into mtNodes"
         except        = throw (BadValueRef callStack cxt explanation ix)
         prj (_, _, x) = x
@@ -180,7 +181,7 @@ mdStringOrEmpty :: HasCallStack
 mdStringOrEmpty cxt partialMeta = fromMaybe "" . mdStringOrNull cxt partialMeta
 
 mkMdRefTable :: MetadataTable -> MdRefTable
-mkMdRefTable mt = Map.mapMaybe step (mtNodes mt)
+mkMdRefTable mt = IntMap.mapMaybe step (mtNodes mt)
   where
   step (fnLocal,_,ix) = do
     guard (not fnLocal)
@@ -314,8 +315,8 @@ finalizePValMd :: PValMd -> Parse ValMd
 finalizePValMd = relabel (const requireBbEntryName)
 
 -- | Partition unnamed entries into global and function local unnamed entries.
-unnamedEntries :: PartialMetadata -> ([PartialUnnamedMd],[PartialUnnamedMd])
-unnamedEntries pm = partitionEithers (mapMaybe resolveNode (Map.toList (mtNodes mt)))
+unnamedEntries :: PartialMetadata -> ([PartialUnnamedMd], [PartialUnnamedMd])
+unnamedEntries pm = partitionEithers (mapMaybe resolveNode (IntMap.toList (mtNodes mt)))
   where
   mt = pmEntries pm
 

--- a/src/Data/LLVM/BitCode/IR/Metadata.hs
+++ b/src/Data/LLVM/BitCode/IR/Metadata.hs
@@ -30,7 +30,7 @@ import           Text.LLVM.Labels
 import qualified Codec.Binary.UTF8.String as UTF8 (decode)
 import           Control.Applicative ((<|>))
 import           Control.Exception (throw)
-import           Control.Monad (foldM,guard,mplus,when)
+import           Control.Monad (foldM, guard, mplus, when)
 import           Data.Bits (shiftR, testBit, shiftL)
 import           Data.Data (Data)
 import           Data.Typeable (Typeable)
@@ -302,7 +302,7 @@ data PartialUnnamedMd = PartialUnnamedMd
   , pumDistinct :: Bool
   } deriving (Data, Eq, Ord, Generic, Show, Typeable)
 
-finalizePartialUnnamedMd :: PartialUnnamedMd -> Parse UnnamedMd
+finalizePartialUnnamedMd :: PartialUnnamedMd -> Finalize UnnamedMd
 finalizePartialUnnamedMd pum = mkUnnamedMd `fmap` finalizePValMd (pumValues pum)
   where
   mkUnnamedMd v = UnnamedMd
@@ -311,7 +311,7 @@ finalizePartialUnnamedMd pum = mkUnnamedMd `fmap` finalizePValMd (pumValues pum)
     , umDistinct = pumDistinct pum
     }
 
-finalizePValMd :: PValMd -> Parse ValMd
+finalizePValMd :: PValMd -> Finalize ValMd
 finalizePValMd = relabel (const requireBbEntryName)
 
 -- | Partition unnamed entries into global and function local unnamed entries.

--- a/src/Data/LLVM/BitCode/IR/Module.hs
+++ b/src/Data/LLVM/BitCode/IR/Module.hs
@@ -69,7 +69,7 @@ finalizeModule pm = label "finalizeModule" $ do
   globals  <- T.mapM finalizeGlobal       (partialGlobals pm)
   declares <- T.mapM finalizeDeclare      (partialDeclares pm)
   aliases  <- T.mapM finalizePartialAlias (partialAliases pm)
-  unnamed  <- T.mapM finalizePartialUnnamedMd (dedupMetadata (partialUnnamedMd pm))
+  unnamed  <- liftFinalize $ T.mapM finalizePartialUnnamedMd (dedupMetadata (partialUnnamedMd pm))
   types    <- resolveTypeDecls
   let lkp = lookupBlockName (partialDefines pm)
   defines <- T.mapM (finalizePartialDefine lkp) (partialDefines pm)

--- a/src/Data/LLVM/BitCode/IR/Types.hs
+++ b/src/Data/LLVM/BitCode/IR/Types.hs
@@ -16,7 +16,6 @@ import qualified Codec.Binary.UTF8.String as UTF8 (decode)
 import           Control.Monad (when,unless,mplus,(<=<))
 import qualified Data.IntMap as IntMap
 import           Data.List (sortBy)
-import qualified Data.Map as Map
 import           Data.Maybe (catMaybes)
 import           Data.Ord (comparing)
 
@@ -30,7 +29,7 @@ numEntry  = hasRecordCode 1 <=< fromUnabbrev <=< unabbrev
 resolveTypeDecls :: Parse [TypeDecl]
 resolveTypeDecls  = do
   symtab <- getTypeSymtab
-  decls  <- mapM mkTypeDecl (Map.toList (tsById symtab))
+  decls  <- mapM mkTypeDecl (IntMap.toList (tsById symtab))
   return (sortBy (comparing typeName) decls)
   where
   mkTypeDecl (ix,alias) = do
@@ -78,7 +77,7 @@ deriveTypeTables cxt tys = (tt,sym)
   -- symbol table.  if the index entry doesn't exist, throw an error, as that
   -- should be impossible.
   tt = IntMap.fromList [ (ix, updateAliases resolve ty) | (ix, (ty, _)) <- ixs ]
-  resolve ix = case Map.lookup ix (tsById sym) of
+  resolve ix = case IntMap.lookup ix (tsById sym) of
     Nothing    -> lookupTypeRef cxt ix tt
     Just ident -> Alias ident
 

--- a/src/Data/LLVM/BitCode/IR/Types.hs
+++ b/src/Data/LLVM/BitCode/IR/Types.hs
@@ -14,6 +14,7 @@ import           Text.LLVM.AST
 
 import qualified Codec.Binary.UTF8.String as UTF8 (decode)
 import           Control.Monad (when,unless,mplus,(<=<))
+import qualified Data.IntMap as IntMap
 import           Data.List (sortBy)
 import qualified Data.Map as Map
 import           Data.Maybe (catMaybes)
@@ -76,7 +77,7 @@ deriveTypeTables cxt tys = (tt,sym)
   -- recursively resolve the type table, if they don't already exist in the
   -- symbol table.  if the index entry doesn't exist, throw an error, as that
   -- should be impossible.
-  tt = Map.fromList [ (ix,updateAliases resolve ty) | (ix,(ty,_)) <- ixs ]
+  tt = IntMap.fromList [ (ix, updateAliases resolve ty) | (ix, (ty, _)) <- ixs ]
   resolve ix = case Map.lookup ix (tsById sym) of
     Nothing    -> lookupTypeRef cxt ix tt
     Just ident -> Alias ident

--- a/src/Data/LLVM/BitCode/IR/Values.hs
+++ b/src/Data/LLVM/BitCode/IR/Values.hs
@@ -2,7 +2,7 @@
 
 module Data.LLVM.BitCode.IR.Values (
     getValueTypePair
-  , getConstantFwdRef, getConstantFwdRefAdjustedId 
+  , getConstantFwdRef, getConstantFwdRefAdjustedId
   , getValue
   , getFnValueById, getFnValueById'
   , parseValueSymbolTableBlock
@@ -15,7 +15,6 @@ import Data.LLVM.BitCode.Record
 import Text.LLVM.AST
 
 import Control.Monad ((<=<),foldM)
-import qualified Data.Map as Map
 
 
 -- Value Table -----------------------------------------------------------------
@@ -112,7 +111,7 @@ vstCodeFNEntry  = hasRecordCode 3 <=< fromEntry
 -- Value Symbol Table Parsing --------------------------------------------------
 
 parseValueSymbolTableBlock :: [Entry] -> Parse ValueSymtab
-parseValueSymbolTableBlock  = foldM parseValueSymbolTableBlockEntry Map.empty
+parseValueSymbolTableBlock  = foldM parseValueSymbolTableBlockEntry mempty
 
 parseValueSymbolTableBlockEntry :: ValueSymtab -> Entry -> Parse ValueSymtab
 

--- a/src/Data/LLVM/BitCode/Parse.hs
+++ b/src/Data/LLVM/BitCode/Parse.hs
@@ -27,6 +27,7 @@ import qualified Codec.Binary.UTF8.String as UTF8 (decode)
 import qualified Control.Exception as X
 import qualified Data.ByteString as BS
 import qualified Data.Map as Map
+import qualified Data.IntMap as IntMap
 import qualified Data.Sequence as Seq
 import           GHC.Stack (HasCallStack, CallStack, callStack, prettyCallStack)
 
@@ -109,7 +110,7 @@ data ParseState = ParseState
 -- | The initial parsing state.
 emptyParseState :: ParseState
 emptyParseState  = ParseState
-  { psTypeTable     = Map.empty
+  { psTypeTable     = IntMap.empty
   , psTypeTableSize = 0
   , psValueTable    = emptyValueTable False
   , psStringTable   = Nothing
@@ -186,11 +187,11 @@ enterFunctionDef m = Parse $ do
 
 -- Type Table ------------------------------------------------------------------
 
-type TypeTable = Map.Map Int Type
+type TypeTable = IntMap.IntMap Type
 
 -- | Generate a type table, and a type symbol table.
 mkTypeTable :: [Type] -> TypeTable
-mkTypeTable  = Map.fromList . zip [0 ..]
+mkTypeTable  = IntMap.fromList . zip [0 ..]
 
 -- | Exceptions contain a callstack, parsing context, explanation, and index
 data BadForwardRef
@@ -221,7 +222,7 @@ lookupTypeRef :: HasCallStack
               => [String] -> Int -> TypeTable -> Type
 lookupTypeRef cxt n =
   let explanation = "Bad reference into type table"
-  in fromMaybe (X.throw (BadTypeRef callStack cxt explanation n)) . Map.lookup n
+  in fromMaybe (X.throw (BadTypeRef callStack cxt explanation n)) . IntMap.lookup n
 
 setTypeTable :: TypeTable -> Parse ()
 setTypeTable table = Parse $ do
@@ -265,7 +266,7 @@ getType' ref = do
 
 -- | Test to see if the type table has been added to already.
 isTypeTableEmpty :: Parse Bool
-isTypeTableEmpty  = Parse (Map.null . psTypeTable <$> get)
+isTypeTableEmpty  = Parse (IntMap.null . psTypeTable <$> get)
 
 setStringTable :: StringTable -> Parse ()
 setStringTable st = Parse $ do

--- a/src/Data/LLVM/CFG.hs
+++ b/src/Data/LLVM/CFG.hs
@@ -29,10 +29,10 @@ import           Control.Applicative
 
 import           Control.Arrow
 
+import           Data.Functor.Identity (runIdentity)
 import qualified Data.Graph.Inductive.Query.Dominators as Dom
 import qualified Data.Graph.Inductive                  as G
 import qualified Data.Map                              as M
-import           MonadLib (runId)
 
 import           Text.LLVM                             hiding (BB)
 import qualified Text.LLVM.Labels                      as L
@@ -171,7 +171,7 @@ buildCFG bs = cfg
 
     nodeByName = fmap (\(BBId n, _) -> n) bbIds
 
-    fixLabels stmts = runId (mapM (L.relabel f) stmts)
+    fixLabels stmts = runIdentity (mapM (L.relabel f) stmts)
       where
       -- This should be fine, as there shouldn't be references to labels that
       -- aren't defined.


### PR DESCRIPTION
This is an implementation of the changes I suggested in the thread for #129.

On the particular 5.6 megabyte bitcode file I was using for test input, this version of `llvm-disasm` runs in about 25% less time, and uses about 33% less memory.