### PR TITLE
Fp80 support

### DIFF
--- a/src/Data/LLVM/BitCode/IR/Constants.hs
+++ b/src/Data/LLVM/BitCode/IR/Constants.hs
@@ -21,6 +21,7 @@ import           Data.Bits (shiftL,shiftR,testBit)
 import qualified Data.LLVM.BitCode.BitString as BitS
 import qualified Data.Map as Map
 import           Data.Maybe (fromMaybe, isJust)
+import           Data.Semigroup ( (<>) )
 import           Data.Word (Word16, Word32,Word64)
 
 #if __GLASGOW_HASKELL__ >= 704
@@ -28,6 +29,8 @@ import           Data.Array.Unsafe (castSTUArray)
 #else
 import           Data.Array.ST (castSTUArray)
 #endif
+
+import           Prelude
 
 
 -- Instruction Field Parsing ---------------------------------------------------

--- a/src/Data/LLVM/BitCode/IR/Constants.hs
+++ b/src/Data/LLVM/BitCode/IR/Constants.hs
@@ -508,8 +508,7 @@ cast x = do
 fp80build :: Type -> Record -> [Typed PValue] -> Parse Type
           -> Parse (Parse Type, [Typed PValue])
 fp80build ty r cs getTy =
-  do -- values <- parseField r 0 (fieldArray numeric)
-     v1 <- parseField r 0 fieldLiteral
+  do v1 <- parseField r 0 fieldLiteral
      v2 <- parseField r 1 fieldLiteral
      let -- Note bs1 <> bs2 results in bs2|bs1 layout, shifting bs2 to higher bits
          v64_0 = BitS.take 64 (BitS.take 16 v2 <> v1)

--- a/src/Data/LLVM/BitCode/IR/Types.hs
+++ b/src/Data/LLVM/BitCode/IR/Types.hs
@@ -130,7 +130,7 @@ parseTypeBlockEntry (fromEntry -> Just r) = case recordCode r of
       rty:ptys -> addType (FunTy rty ptys va)
       _        -> fail "function expects a return type"
 
-  10 -> label "TYPE_CODE_X86_FP80" (addType (PrimType (FloatType Half)))
+  10 -> label "TYPE_CODE_FP_HALF" (addType (PrimType (FloatType Half)))
 
   11 -> label "TYPE_CODE_ARRAY" $ do
     let field = parseField r

--- a/unit-test/Tests/Instances.hs
+++ b/unit-test/Tests/Instances.hs
@@ -44,6 +44,7 @@ instance Arbitrary lab => Arbitrary (Instr' lab)                      where arbi
 instance Arbitrary lab => Arbitrary (Clause' lab)                     where arbitrary = genericArbitrary uniform
 instance Arbitrary ICmpOp                                             where arbitrary = genericArbitrary uniform
 instance Arbitrary FCmpOp                                             where arbitrary = genericArbitrary uniform
+instance Arbitrary FP80Value                                          where arbitrary = genericArbitrary uniform
 instance Arbitrary lab => Arbitrary (Value' lab)                      where arbitrary = genericArbitrary uniform
 instance Arbitrary lab => Arbitrary (ValMd' lab)                      where arbitrary = genericArbitrary uniform
 instance Arbitrary lab => Arbitrary (DebugLoc' lab)                   where arbitrary = genericArbitrary uniform


### PR DESCRIPTION
Resolves https://github.com/GaloisInc/llvm-pretty-bc-parser/issues/121

Note that this does not use the long-double package as identified in that issue.  The primary reason for this was that the long-double package is very focused on FFI interaction, which has the advantage that C library fpFUNC() calls can be used to implement fp80 operations, but it also seems to come with some significant performance overheads/warnings.  The implementation here (and in llvm-pretty) just uses a simple datatype to store the exponent and significant values, leaving any semantic interpretation and manipulation to consumers.  If there is interest in switching to an implementation based on the  long-double package in the future it should be a very simple change to make.