### PR TITLE
Stricter parsing for numeric values

### DIFF
--- a/src/Data/LLVM/BitCode/IR/Constants.hs
+++ b/src/Data/LLVM/BitCode/IR/Constants.hs
@@ -392,9 +392,8 @@ parseConstantEntry t (getTy,cs) (fromEntry -> Just r) =
       Integer 16         -> build ValInteger
       Integer 32         -> build ValInteger
       Integer 64         -> build ValInteger
---      FloatType Float    -> build ValFloat
---      FloatType Double   -> build ValDouble
---      FloatType X86_fp80 -> error "TBD: similar to `fp80buildData ty r cs getTy`, but potentially applied iteratively"
+      FloatType Float    -> build (ValFloat . castFloat)
+      FloatType Double   -> build (ValDouble . castDouble)
       x                  -> Assert.unknownEntity "element type" x
 
   23 -> label "CST_CODE_INLINEASM" $ do

--- a/src/Data/LLVM/BitCode/IR/Constants.hs
+++ b/src/Data/LLVM/BitCode/IR/Constants.hs
@@ -17,7 +17,7 @@ import qualified Codec.Binary.UTF8.String as UTF8 (decode)
 import           Control.Monad (mplus,mzero,foldM,(<=<))
 import           Control.Monad.ST (runST,ST)
 import           Data.Array.ST (newArray,readArray,MArray,STUArray)
-import           Data.Bits (shiftL,shiftR,testBit)
+import           Data.Bits (shiftL,shiftR,testBit, Bits)
 import qualified Data.LLVM.BitCode.BitString as BitS
 import qualified Data.Map as Map
 import           Data.Maybe (fromMaybe, isJust)
@@ -225,7 +225,7 @@ parseConstantEntry t (getTy,cs) (fromEntry -> Just r) =
     ty <- getTy
     ft <- (elimFloatType =<< elimPrimType ty)
         `mplus` fail "expecting a float type"
-    let build :: Num a => (a -> PValue) -> Parse (Parse Type, [Typed PValue])
+    let build :: (Num a, Bits a) => (a -> PValue) -> Parse (Parse Type, [Typed PValue])
         build k = do
           a <-  parseField r 0 (fmap k . numeric)
           return (getTy, (Typed ty $! a):cs)
@@ -392,9 +392,9 @@ parseConstantEntry t (getTy,cs) (fromEntry -> Just r) =
       Integer 16         -> build ValInteger
       Integer 32         -> build ValInteger
       Integer 64         -> build ValInteger
-      FloatType Float    -> build ValFloat
-      FloatType Double   -> build ValDouble
-      FloatType X86_fp80 -> error "TBD: similar to `fp80buildData ty r cs getTy`, but potentially applied iteratively"
+--      FloatType Float    -> build ValFloat
+--      FloatType Double   -> build ValDouble
+--      FloatType X86_fp80 -> error "TBD: similar to `fp80buildData ty r cs getTy`, but potentially applied iteratively"
       x                  -> Assert.unknownEntity "element type" x
 
   23 -> label "CST_CODE_INLINEASM" $ do

--- a/src/Data/LLVM/BitCode/IR/Function.hs
+++ b/src/Data/LLVM/BitCode/IR/Function.hs
@@ -21,7 +21,7 @@ import           Text.LLVM.Labels
 import           Text.LLVM.PP
 
 import           Control.Monad (when,unless,mplus,mzero,foldM,(<=<),msum)
-import           Data.Bits (shiftR,bit,shiftL,testBit,(.&.),(.|.),complement)
+import           Data.Bits (shiftR,bit,shiftL,testBit,(.&.),(.|.),complement,Bits)
 import           Data.Int (Int32)
 import           Data.Maybe (isJust)
 import           Data.Word (Word32)
@@ -1202,7 +1202,7 @@ interpGep ty vs = check (resolveGep ty vs)
       ty' <- getType' =<< getTypeId i
       check (k ty')
 
-parseIndexes :: Num a => Record -> Int -> Parse [a]
+parseIndexes :: (Num a, Bits a) => Record -> Int -> Parse [a]
 parseIndexes r = loop
   where
   field  = parseField r
@@ -1259,7 +1259,7 @@ parseSwitchLabels ty r = loop
 
 -- | See the comment for 'parseSwitchLabels' for information about what this
 -- does.
-parseNewSwitchLabels :: Int32 -> Record -> Int -> Int -> Parse [(Integer,Int)]
+parseNewSwitchLabels :: Word32 -> Record -> Int -> Int -> Parse [(Integer,Int)]
 parseNewSwitchLabels width r = loop
   where
   field = parseField r

--- a/src/Data/LLVM/BitCode/IR/Metadata.hs
+++ b/src/Data/LLVM/BitCode/IR/Metadata.hs
@@ -31,7 +31,7 @@ import qualified Codec.Binary.UTF8.String as UTF8 (decode)
 import           Control.Applicative ((<|>))
 import           Control.Exception (throw)
 import           Control.Monad (foldM, guard, mplus, when)
-import           Data.Bits (shiftR, testBit, shiftL)
+import           Data.Bits (shiftR, testBit, shiftL, (.&.), (.|.), bit, complement)
 import           Data.Data (Data)
 import           Data.Typeable (Typeable)
 import qualified Data.ByteString as S
@@ -645,25 +645,92 @@ parseMetadataEntry vt mt pm (fromEntry -> Just r) =
 
     21 -> label "METADATA_SUBPROGRAM" $ do
       -- this one is a bit funky:
-      -- https://github.com/llvm-mirror/llvm/blob/release_50/lib/Bitcode/Reader/MetadataLoader.cpp#L1382
+      -- https://github.com/llvm/llvm-project/blob/release/10.x/llvm/lib/Bitcode/Reader/MetadataLoader.cpp#L1486
+
+      assertRecordSizeBetween 18 21
 
       -- A "version" is encoded in the high-order bits of the isDistinct field.
       -- We parse it once here as a numeric value, and later as a Bool.
       version <- parseField r 0 numeric
-      assertRecordSizeBetween 18 21
+
+      let hasSPFlags = (version .&. (0x4 :: Word32)) /= 0;
+
+      (diFlags0, spFlags0) <-
+        if hasSPFlags then
+          (,) <$> parseField r (11 + 2) numeric <*> pure 0
+        else
+          (,) <$> parseField r 11 numeric <*> parseField r 9 numeric
+
+      let diFlagMainSubprogram = bit 21 :: Word32
+          hasOldMainSubprogramFlag = (diFlags0 .&. diFlagMainSubprogram) /= 0
+
+          -- CF https://github.com/llvm/llvm-project/blob/release/10.x/llvm/include/llvm/IR/DebugInfoFlags.def
+          spFlagIsLocal      = bit 2
+          spFlagIsDefinition = bit 3
+          spFlagIsOptimized  = bit 4
+          spFlagIsMain       = bit 8
+
+          diFlags
+            | hasOldMainSubprogramFlag = diFlags0 .&. complement diFlagMainSubprogram
+            | otherwise                = diFlags0
+
+          spFlags
+            | hasOldMainSubprogramFlag = spFlags0 .|. spFlagIsMain
+            | otherwise                = spFlags0
+
+      -- TODO, isMain isn't exposed via DISubprogram
+      (isLocal, isDefinition, isOptimized, virtuality, _isMain) <-
+        if hasSPFlags then
+          let spIsLocal       = spFlags .&. spFlagIsLocal /= 0
+              spIsDefinition  = spFlags .&. spFlagIsDefinition /= 0
+              spIsOptimized   = spFlags .&. spFlagIsOptimized /= 0
+              spIsMain        = spFlags .&. spFlagIsMain /= 0
+              spVirtuality    = spFlags .&. 0x3
+           in return (spIsLocal, spIsDefinition, spIsOptimized, spVirtuality, spIsMain)
+        else
+          do (,,,,) <$>
+               parseField r 7 nonzero <*>  -- isLocal
+               parseField r 8 nonzero <*>  -- isDefinition
+               parseField r 14 nonzero <*> -- isOptimized
+               parseField r 11 numeric <*> -- virtuality
+               pure hasOldMainSubprogramFlag -- isMain
+
       let recordSize = length (recordFields r)
-          adj i | recordSize == 19 = i + 1
-                | otherwise        = i
-          hasThisAdjustment = recordSize >= 20
-          hasThrownTypes    = recordSize >= 21
-          hasUnit           = version >= (2 :: Int) -- avoid default type
 
-      ctx          <- getContext
+          isDistinct = (version .&. 0x1 /= 0) || (spFlags .&. spFlagIsDefinition /= 0)
 
-      -- See https://github.com/elliottt/llvm-pretty/issues/47
-      -- and the corresponding LLVM code in MetadataLoader.cpp (parseOneMetadata)
-      isDefinition <- parseField r 8 nonzero                       -- dispIsDefinition
-      isDistinct   <- (isDefinition ||) <$> parseField r 0 nonzero -- isDistinct
+          hasUnit = version .&. 0x2 /= 0
+
+          offsetA
+            | not hasSPFlags = 2
+            | otherwise      = 0
+
+          offsetB
+            | not hasSPFlags && recordSize >= 19 = 3
+            | not hasSPFlags                     = 2
+            | otherwise                          = 0
+
+          -- this doesn't seem to be used in our parser...
+          --hasFn
+          --  | not hasSPFlags && recordSize >= 19 = not hasUnit
+          --  | otherwise = False
+
+          hasThisAdjustment
+            | not hasSPFlags = recordSize >= 20
+            | otherwise      = True
+
+          hasThrownTypes
+            | not hasSPFlags = recordSize >= 21
+            | otherwise      = True
+
+      -- Some additional sanity checking
+      when (not hasSPFlags && hasUnit)
+           (assertRecordSizeBetween 18 19)
+
+      when (hasSPFlags && not hasUnit)
+           (fail "DISubprogram record has subprogram flags, but does not have unit.  Invalid record.")
+
+      ctx <- getContext
 
       -- Forward references that depend on the 'version'
       let optFwdRef b n =
@@ -672,29 +739,29 @@ parseMetadataEntry vt mt pm (fromEntry -> Just r) =
             else pure Nothing
 
       disp         <- DISubprogram
-        <$> (mdForwardRefOrNull ctx mt <$> parseField r 1 numeric)        -- dispScope
-        <*> (mdStringOrNull     ctx pm <$> parseField r 2 numeric)        -- dispName
-        <*> (mdStringOrNull     ctx pm <$> parseField r 3 numeric)        -- dispLinkageName
-        <*> (mdForwardRefOrNull ctx mt <$> parseField r 4 numeric)        -- dispFile
-        <*>                                parseField r 5 numeric         -- dispLine
-        <*> (mdForwardRefOrNull ctx mt <$> parseField r 6 numeric)        -- dispType
-        <*>                                parseField r 7 nonzero         -- dispIsLocal
-        <*>                                pure isDefinition              -- dispIsDefinition
-        <*>                                parseField r 9 numeric         -- dispScopeLine
-        <*> (mdForwardRefOrNull ctx mt <$> parseField r 10 numeric)       -- dispContainingType
-        <*>                                parseField r 11 numeric        -- dispVirtuality
-        <*>                                parseField r 12 numeric        -- dispVirtualIndex
+        <$> (mdForwardRefOrNull ctx mt <$> parseField r 1 numeric)             -- dispScope
+        <*> (mdStringOrNull     ctx pm <$> parseField r 2 numeric)             -- dispName
+        <*> (mdStringOrNull     ctx pm <$> parseField r 3 numeric)             -- dispLinkageName
+        <*> (mdForwardRefOrNull ctx mt <$> parseField r 4 numeric)             -- dispFile
+        <*>                                parseField r 5 numeric              -- dispLine
+        <*> (mdForwardRefOrNull ctx mt <$> parseField r 6 numeric)             -- dispType
+        <*>                                pure isLocal                        -- dispIsLocal
+        <*>                                pure isDefinition                   -- dispIsDefinition
+        <*>                                parseField r (7 + offsetA) numeric  -- dispScopeLine
+        <*> (mdForwardRefOrNull ctx mt <$> parseField r (8 + offsetA) numeric) -- dispContainingType
+        <*>                                pure virtuality                     -- dispVirtuality
+        <*>                                parseField r (10 + offsetA) numeric -- dispVirtualIndex
         <*> (if hasThisAdjustment
-            then parseField r 19 numeric
-            else return 0)                                                -- dispThisAdjustment
-        <*> parseField r 13 numeric                                       -- dispFlags
-        <*> parseField r 14 nonzero                                       -- dispIsOptimized
-        <*> (optFwdRef hasUnit       15)                                  -- dispUnit
-        <*> (optFwdRef (not hasUnit) (adj 15))                            -- dispTemplateParams
-        <*> (mdForwardRefOrNull ctx mt <$> parseField r (adj 16) numeric) -- dispDeclaration
-        <*> (mdForwardRefOrNull ctx mt <$> parseField r (adj 17) numeric) -- dispVariables
-        -- Indices 18-19 seem unused.
-        <*> (optFwdRef hasThrownTypes 20)                                 -- dispThrownTypes
+            then parseField r (16 + offsetB) numeric
+            else return 0)                                                      -- dispThisAdjustment
+        <*> pure diFlags                                                        -- dispFlags
+        <*> pure isOptimized                                                    -- dispIsOptimized
+        <*> (optFwdRef hasUnit (12 + offsetB))                                  -- dispUnit
+        <*> (mdForwardRefOrNull ctx mt <$> parseField r (13 + offsetB) numeric) -- dispTemplateParams
+        <*> (mdForwardRefOrNull ctx mt <$> parseField r (14 + offsetB) numeric) -- dispDeclaration
+        <*> (mdForwardRefOrNull ctx mt <$> parseField r (15 + offsetB) numeric) -- dispVariables
+        <*> (optFwdRef hasThrownTypes (17 + offsetB))                           -- dispThrownTypes
+
       -- TODO: in the LLVM parser, it then goes into the metadata table
       -- and updates function entries to point to subprograms. Is that
       -- neccessary for us?

--- a/src/Data/LLVM/BitCode/IR/Metadata.hs
+++ b/src/Data/LLVM/BitCode/IR/Metadata.hs
@@ -725,7 +725,7 @@ parseMetadataEntry vt mt pm (fromEntry -> Just r) =
 
       -- Some additional sanity checking
       when (not hasSPFlags && hasUnit)
-           (assertRecordSizeBetween 18 19)
+           (assertRecordSizeBetween 19 21)
 
       when (hasSPFlags && not hasUnit)
            (fail "DISubprogram record has subprogram flags, but does not have unit.  Invalid record.")

--- a/src/Data/LLVM/BitCode/Record.hs
+++ b/src/Data/LLVM/BitCode/Record.hs
@@ -116,7 +116,7 @@ parseSlice r l n p = loop (take n (drop l (recordFields r)))
   loop []     = return []
 
 -- | Parse a @Field@ as a numeric value.
-numeric :: Num a => Match Field a
+numeric :: (Num a, Bits a) => Match Field a
 numeric  = fmap fromBitString . (fieldLiteral ||| fieldFixed ||| fieldVbr)
 
 signedImpl :: (Bits a, Num a) => Match Field a
@@ -157,7 +157,7 @@ nonzero  = decode <=< (fieldFixed ||| fieldLiteral ||| fieldVbr)
     | otherwise      = return True
 
 char :: Match Field Word8
-char  = numeric
+char = numeric
 
 string :: Match Field String
 string  = fmap UTF8.decode . fieldArray char


### PR DESCRIPTION
Check that the parsed value actually fits into the type of value we are parsing, and fail if it does not.

In the process of making this change, it became apparent that
some of the code for parsing floating-point values was incorrectly
interpreting the bitstrings.  This will be fixed in a subsequent
patch.