### PR TITLE
Update llvm-pretty version constraint to 0.11.*.

### DIFF
--- a/llvm-pretty-bc-parser.cabal
+++ b/llvm-pretty-bc-parser.cabal
@@ -67,7 +67,7 @@ Library
                        bytestring >= 0.9.1,
                        utf8-string>= 1.0,
                        uniplate   >= 1.6,
-                       llvm-pretty>= 0.10.3
+                       llvm-pretty>= 0.11 && < 0.12
 
 Executable llvm-disasm
   Main-is:             LLVMDis.hs
@@ -83,7 +83,7 @@ Executable llvm-disasm
                        fgl        >= 5.5,
                        fgl-visualize >= 0.1,
                        cereal     >= 0.3.5.2,
-                       llvm-pretty== 0.10.*,
+                       llvm-pretty,
                        pretty-show>= 1.6,
                        llvm-pretty-bc-parser
 
@@ -121,7 +121,7 @@ Test-suite disasm-test
                        filepath,
                        pretty-show>= 1.6,
                        syb        >= 0.7,
-                       llvm-pretty== 0.10.*,
+                       llvm-pretty,
                        llvm-pretty-bc-parser
 
 Executable regression-test
@@ -135,7 +135,7 @@ Executable regression-test
                        foldl,
                        text,
                        turtle,
-                       llvm-pretty== 0.10.*,
+                       llvm-pretty,
                        llvm-pretty-bc-parser
   if flag(regressions)
       Buildable:       True
@@ -161,7 +161,7 @@ Executable fuzz-llvm-disasm
                        abstract-par,
                        monad-par,
                        transformers,
-                       llvm-pretty== 0.10.*,
+                       llvm-pretty,
                        llvm-pretty-bc-parser
   if flag(fuzz)
       Buildable:       True


### PR DESCRIPTION
Code has already been changed accordingly, and llvm-pretty updated the
version to 0.11.0 to reflect its changes.