### PR TITLE
Retry curl on failure for llvm quick fuzz

### DIFF
--- a/.github/workflows/llvm-quick-fuzz.yml
+++ b/.github/workflows/llvm-quick-fuzz.yml
@@ -49,9 +49,8 @@ jobs:
       - shell: bash
         name: Install LLVM
         run: |
-          curl -L ${{ matrix.llvm }} -o llvm.tar.xz
-          tar xzf llvm.tar.xz
-          mv clang+llvm-* llvm
+          { curl -sSL ${{ matrix.llvm }} -o llvm.tar.xz && tar xzf llvm.tar.xz && mv clang+llvm-* llvm ; } || \
+          { curl -sSL ${{ matrix.llvm }} -o llvm.tar.xz && tar xzf llvm.tar.xz && mv clang+llvm-* llvm ; }
           echo "$PWD/llvm/bin" >> $GITHUB_PATH
 
       - shell: bash


### PR DESCRIPTION
We've been getting spurious failures from downloading LLVM. I suspect it might be rate limiting or something to that effect. So I'm going to try a naive retry and see if that works.