### PR TITLE
Support parsing `fneg` instructions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,11 +36,6 @@ jobs:
           key: cabal-${{ runner.os }}-${{ matrix.ghc }}-${{ github.sha }}
           restore-keys: cabal-${{ runner.os }}-${{ matrix.ghc }}-
 
-      - uses: actions/checkout@v2
-        with:
-          repository: elliottt/llvm-pretty
-          path: llvm-pretty
-
       - name: Build
         run: cabal build --enable-tests
 

--- a/.github/workflows/llvm-quick-fuzz.yml
+++ b/.github/workflows/llvm-quick-fuzz.yml
@@ -31,6 +31,8 @@ jobs:
     name: llvm-quick-fuzz - ${{ matrix.llvm }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: true
 
       - uses: haskell/actions/setup@v1
         id: setup-haskell
@@ -41,11 +43,6 @@ jobs:
         run: |
           brew install csmith creduce
           ln -s /usr/local/opt/csmith/include/csmith-* $PWD/csmith-include
-
-      - uses: actions/checkout@v2
-        with:
-          repository: elliottt/llvm-pretty
-          path: llvm-pretty
 
       - shell: bash
         name: Install LLVM

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ cabal.sandbox.config
 /fuzz-temp-test.c
 /fuzz-temp-test.bc
 /fuzz-results
-/llvm-pretty

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "llvm-pretty"]
+	path = llvm-pretty
+	url = https://github.com/elliottt/llvm-pretty

--- a/disasm-test/tests/fneg.ll
+++ b/disasm-test/tests/fneg.ll
@@ -1,0 +1,14 @@
+define double @real_fneg(double %X) {
+        %Y = fneg double %X               ; <double> [#uses=1]
+        ret double %Y
+}
+
+define double @real_fneg_constant() {
+        %Y = fneg double -2.0             ; <double> [#uses=1]
+        ret double %Y
+}
+
+define float @real_fnegf(float %X) {
+        %Y = fneg float %X                ; <float> [#uses=1]
+        ret float %Y
+}

--- a/doc/developing.md
+++ b/doc/developing.md
@@ -5,6 +5,7 @@
 
 - [Developers' documentation](#developers-documentation)
     - [Upstream documentation](#upstream-documentation)
+    - [Building](#building)
     - [Running the tests](#running-the-tests)
         - [`llvm-disasm-test`](#llvm-disasm-test)
             - [description](#description)
@@ -33,6 +34,15 @@ C++ implementation:
      - [Release 4.0](https://github.com/llvm-mirror/llvm/blob/release_40/include/llvm/Bitcode/LLVMBitCodes.h)
      - [Release 5.0](https://github.com/llvm-mirror/llvm/blob/release_50/include/llvm/Bitcode/LLVMBitCodes.h)
      - [Release 6.0](https://github.com/llvm-mirror/llvm/blob/release_60/include/llvm/Bitcode/LLVMBitCodes.h)
+
+## Building
+
+Make sure you have cloned the `llvm-pretty` submodule before building:
+
+```bash
+$ git submodule update --init
+$ cabal build
+```
 
 ## Running the tests
 
@@ -82,29 +92,3 @@ See [the README in that directory](../fuzzing/README.md).
 ### `unit-test`
 
 These are run with `cabal test` or `cabal new-test`.
-
-## Travis CI build
-
-**Note**: the CI build doesn't run the full test suite, just some regression
-tests and the unit tests.
-
-The `.travis.yml` file is generated using
-[haskell-ci](https://github.com/haskell-CI/haskell-ci). However, we add the 
-following:
-```yml
-  - git clone https://github.com/elliottt/llvm-pretty llvm-pretty
-  - "printf 'packages: \".\" llvm-pretty/\\n' > cabal.project"
-```
-and:
-```yml
-  - git clone https://github.com/elliottt/llvm-pretty llvm-pretty
-  - "printf 'packages: llvm-pretty-bc-parser-*/*.cabal llvm-pretty/*.cabal\\n' > cabal.project"
-```
-so that it picks up the latest `llvm-pretty`.
-
-
-When Cabal [supports fetching tarballs](https://github.com/haskell/cabal/issues/2189), 
-we can use the following so that it fetches the latest `llvm-pretty` from Github.
-```yml
-  - "printf 'packages: llvm-pretty-bc-parser-*/*.cabal https://github.com/elliottt/llvm-pretty/archive/master.tar.gz \\n' > cabal.project"
-```

--- a/src/Data/LLVM/BitCode/IR/Function.hs
+++ b/src/Data/LLVM/BitCode/IR/Function.hs
@@ -975,6 +975,14 @@ parseFunctionBlockEntry _ t d (fromEntry -> Just r) = case recordCode r of
   55 -> label "FUNC_CODE_OPERAND_BUNDLE" $ do
     notImplemented
 
+  -- [opval,ty,opcode]
+  56 -> label "FUNC_CODE_INST_UNOP" $ do
+    let field = parseField r
+    (v,ix)  <- getValueTypePair t r 0
+    mkInstr <- field ix unop
+    result (typedType v) (mkInstr v) d
+
+
   -- [opty,opval,opval,pred]
   code
    |  code == 9

--- a/unit-test/Tests/Instances.hs
+++ b/unit-test/Tests/Instances.hs
@@ -36,6 +36,7 @@ instance Arbitrary Linkage                                            where arbi
 instance Arbitrary Visibility                                         where arbitrary = genericArbitrary uniform
 instance Arbitrary lab => Arbitrary (Typed lab)                       where arbitrary = genericArbitrary uniform
 instance Arbitrary ArithOp                                            where arbitrary = genericArbitrary uniform
+instance Arbitrary UnaryArithOp                                       where arbitrary = genericArbitrary uniform
 instance Arbitrary BitOp                                              where arbitrary = genericArbitrary uniform
 instance Arbitrary ConvOp                                             where arbitrary = genericArbitrary uniform
 instance Arbitrary AtomicRWOp                                         where arbitrary = genericArbitrary uniform


### PR DESCRIPTION
This is sufficient to parse the SQLite test case mentioned in #148. I have added a much more minimal test case which exercises the new `fneg`-related code paths added in this patch.

Fixes #148. This includes #154.