### PR TITLE
Build warning-free on GHC 9.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        ghc: ["8.6.5", "8.8.4", "8.10.7"]
+        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.1"]
     name: build - ${{ matrix.ghc }} - ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        ghc: ["8.6.5", "8.8.4", "8.10.2"]
+        ghc: ["8.6.5", "8.8.4", "8.10.7"]
     name: build - ${{ matrix.ghc }} - ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/llvm-quick-fuzz.yml
+++ b/.github/workflows/llvm-quick-fuzz.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
-        ghc: ["8.10.4"]
+        ghc: ["8.10.7"]
         llvm: [ "https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.0/clang+llvm-12.0.0-x86_64-apple-darwin.tar.xz"
               , "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/clang+llvm-11.0.0-x86_64-apple-darwin.tar.xz"
               , "https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.1/clang+llvm-10.0.1-x86_64-apple-darwin.tar.xz"

--- a/disasm-test/Main.hs
+++ b/disasm-test/Main.hs
@@ -13,7 +13,7 @@ import qualified Data.ByteString.Lazy as L
 import           Data.Char (ord,isSpace,chr)
 import           Data.Generics (everywhere, mkT) -- SYB
 import           Data.List (sort)
-import           Data.Monoid ( mconcat, Endo(..) )
+import           Data.Monoid ( Endo(..) )
 import           Data.Typeable (Typeable)
 import           System.Console.GetOpt
            ( ArgOrder(..), ArgDescr(..), OptDescr(..), getOpt, usageInfo )

--- a/src/Data/LLVM/BitCode/BitString.hs
+++ b/src/Data/LLVM/BitCode/BitString.hs
@@ -8,7 +8,6 @@ module Data.LLVM.BitCode.BitString (
   ) where
 
 import Data.Bits ((.&.),(.|.),shiftL,shiftR,bit,bitSizeMaybe, Bits)
-import Data.Monoid (Monoid(..))
 import Data.Semigroup
 import Numeric (showIntAtBase)
 

--- a/src/Data/LLVM/BitCode/IR.hs
+++ b/src/Data/LLVM/BitCode/IR.hs
@@ -14,7 +14,6 @@ import Data.LLVM.BitCode.Record
 import Text.LLVM.AST
 
 import Control.Monad (unless,forM_)
-import Data.Monoid (mappend)
 import Data.Word (Word16)
 
 

--- a/src/Data/LLVM/BitCode/Parse.hs
+++ b/src/Data/LLVM/BitCode/Parse.hs
@@ -57,8 +57,10 @@ newtype Parse a = Parse
   } deriving (Functor, Applicative, MonadFix)
 
 instance Monad Parse where
+#if !MIN_VERSION_base(4,11,0)
   {-# INLINE return #-}
-  return  = Parse . return
+  return = pure
+#endif
 
   {-# INLINE (>>=) #-}
   Parse m >>= f = Parse (m >>= unParse . f)
@@ -738,8 +740,10 @@ newtype Finalize a = Finalize
   } deriving (Functor, Applicative)
 
 instance Monad Finalize where
+#if !MIN_VERSION_base(4,11,0)
   {-# INLINE return #-}
-  return  = Finalize . return
+  return = pure
+#endif
 
   {-# INLINE (>>=) #-}
   Finalize m >>= f = Finalize (m >>= unFinalize . f)

--- a/src/Data/LLVM/BitCode/Parse.hs
+++ b/src/Data/LLVM/BitCode/Parse.hs
@@ -13,7 +13,6 @@ import           Text.LLVM.AST
 import           Text.LLVM.PP
 
 import           Control.Applicative (Alternative(..))
-import           Control.Monad.Fix (MonadFix)
 #if !MIN_VERSION_base(4,13,0)
 import           Control.Monad.Fail (MonadFail)
 import qualified Control.Monad.Fail -- makes fail visible for instance

--- a/src/Data/LLVM/BitCode/Record.hs
+++ b/src/Data/LLVM/BitCode/Record.hs
@@ -13,7 +13,7 @@ import Data.Word (Word8,Word32,Word64)
 import Data.ByteString (ByteString)
 
 import qualified Codec.Binary.UTF8.String as UTF8 (decode)
-import Control.Monad ((<=<),MonadPlus(..),guard)
+import Control.Monad ((<=<),MonadPlus(..))
 
 
 -- Generic Records -------------------------------------------------------------
@@ -36,8 +36,7 @@ fromUnabbrev u = return Record
 -- | Record construction from an abbreviated field.
 fromAbbrev :: Match AbbrevRecord Record
 fromAbbrev a = do
-  guard (not (null (abbrevFields a)))
-  let (f:fs) = abbrevFields a
+  (f:fs) <- return $ abbrevFields a
   code <- numeric f
   return Record
     { recordCode   = code

--- a/src/Data/LLVM/BitCode/Record.hs
+++ b/src/Data/LLVM/BitCode/Record.hs
@@ -36,6 +36,8 @@ fromUnabbrev u = return Record
 -- | Record construction from an abbreviated field.
 fromAbbrev :: Match AbbrevRecord Record
 fromAbbrev a = do
+  -- If abbrevFields is empty here, it will cause the Match to fail with
+  -- Nothing, at which point alternatives may then be tried.
   (f:fs) <- return $ abbrevFields a
   code <- numeric f
   return Record


### PR DESCRIPTION
While `llvm-pretty-bc-parser` does technically build on GHC 9.2 already, it produces a fair number of warnings in the process. Several of these warnings are new in GHC 9.2, as 9.2 added `-Wnoncanonical-monad-instances`, `-Wnoncanonical-monoid-instances`, and `-Wincomplete-uni-patterns` to `-Wall`. This PR fixes all of these warnings and makes sure that CI tests 9.2.