### PR TITLE
Support parsing `FUNC_CODE_INST_ATOMICRMW` (59) function codes

### DIFF
--- a/disasm-test/tests/atomicrmw.ll
+++ b/disasm-test/tests/atomicrmw.ll
@@ -1,0 +1,4 @@
+define void @atomicrmw(i32* %a, i32 %i) {
+    %b = atomicrmw add i32* %a, i32 %i acquire
+    ret void
+}


### PR DESCRIPTION
What was previously named `FUNC_CODE_INST_ATOMICRMW` (code 38) is now named `FUNC_CODE_INST_ATOMICRMW_OLD`. The new `FUNC_CODE_INST_ATOMICRMW` (code 59), introduced in LLVM 13, is like `FUNC_CODE_INST_ATOMICRMW_OLD`, except that it has an explicit `valty` field to go along with its `val` field. To accommodate this, we augment `parseAtomicRMW` to check if we are dealing with the old or new function code, and if it is the latter, we parse a type-value pair instead of just a value. This requires rearranging the code a bit to get the indices correct, but nothing too drastic.

I've included a disassembly test and verified that it works both before and after LLVM 13 (i.e., with both forms of instruction code).

Fixes #175.