### PR TITLE
Clarify and isolate the BitString interface

### DIFF
--- a/src/Data/LLVM/BitCode/BitString.hs
+++ b/src/Data/LLVM/BitCode/BitString.hs
@@ -6,7 +6,6 @@ module Data.LLVM.BitCode.BitString (
   , showBitString
   , fromBitString
   , bitStringValue
-  , maskBits
   , take, drop
   , NumBits, NumBytes, pattern Bits', pattern Bytes'
   , bitCount

--- a/src/Data/LLVM/BitCode/BitString.hs
+++ b/src/Data/LLVM/BitCode/BitString.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 module Data.LLVM.BitCode.BitString (
     BitString(BitString)
   , toBitString
@@ -6,6 +8,10 @@ module Data.LLVM.BitCode.BitString (
   , bitStringValue
   , maskBits
   , take, drop
+  , NumBits, NumBytes, pattern Bits', pattern Bytes'
+  , bitCount
+  , addBitCounts
+  , subtractBitCounts
   ) where
 
 import Data.Bits ((.&.),(.|.),shiftL,shiftR,bit,bitSizeMaybe, Bits)
@@ -14,8 +20,28 @@ import Numeric (showIntAtBase)
 
 import Prelude hiding (take,drop,splitAt)
 
+newtype NumBits = NumBits Int deriving (Show, Eq, Ord)
+newtype NumBytes = NumBytes Int deriving (Show, Eq, Ord)
+
+pattern Bits' :: Int -> NumBits
+pattern Bits' n = NumBits n
+{-# COMPLETE Bits' #-}
+
+pattern Bytes' :: Int -> NumBytes
+pattern Bytes' n = NumBytes n
+{-# COMPLETE Bytes' #-}
+
+bitCount :: NumBits -> Int
+bitCount (NumBits n) = n
+
+addBitCounts :: NumBits -> NumBits -> NumBits
+addBitCounts (NumBits a) (NumBits b) = NumBits $ a + b
+
+subtractBitCounts :: NumBits -> NumBits -> NumBits
+subtractBitCounts (NumBits a) (NumBits b) = NumBits $ a - b
+
 data BitString = BitString
-  { bsLength :: !Int
+  { bsLength :: !NumBits
   , bsData   :: !Integer
   } deriving Show
 
@@ -23,15 +49,15 @@ instance Eq BitString where
   BitString n i == BitString m j = n == m && i == j
 
 instance Semigroup BitString where
-  BitString n i <> BitString m j =
-    BitString (n+m) (i .|. (j `shiftL` n))
+  BitString n@(NumBits n') i <> BitString m j =
+    BitString (addBitCounts n m) (i .|. (j `shiftL` n'))
 
 instance Monoid BitString where
-  mempty = BitString 0 0
+  mempty = BitString (NumBits 0) 0
   mappend = (<>)
 
 -- | Given a number of bits to take, and an @Integer@, create a @BitString@.
-toBitString :: Int -> Integer -> BitString
+toBitString :: NumBits -> Integer -> BitString
 toBitString len val = BitString len (val .&. maskBits len)
 
 bitStringValue :: BitString -> Integer
@@ -56,24 +82,26 @@ showBitString :: BitString -> ShowS
 showBitString bs = showString padding . showString bin
   where
   bin     = showIntAtBase 2 fmt (bsData bs) ""
-  padding = replicate (bsLength bs - length bin) '0'
+  padding = replicate (bitCount (bsLength bs) - length bin) '0'
   fmt 0   = '0'
   fmt 1   = '1'
   fmt _   = error "invalid binary digit value"
 
 
 -- | Generate a mask from a number of bits desired.
-maskBits :: Int -> Integer
-maskBits len
+maskBits :: NumBits -> Integer
+maskBits (NumBits len)
   | len <= 0  = 0
   | otherwise = pred (bit len)
 
-take :: Int -> BitString -> BitString
+take :: NumBits -> BitString -> BitString
 take n bs@(BitString l i)
   | n >= l    = bs
   | otherwise = toBitString n i
 
-drop :: Int -> BitString -> BitString
+drop :: NumBits -> BitString -> BitString
 drop n (BitString l i)
   | n >= l    = mempty
-  | otherwise = BitString (l - n) (i `shiftR` n)
+  | otherwise = BitString
+                (NumBits $ bitCount l - bitCount n)
+                (i `shiftR` (bitCount n))

--- a/src/Data/LLVM/BitCode/BitString.hs
+++ b/src/Data/LLVM/BitCode/BitString.hs
@@ -1,8 +1,9 @@
 module Data.LLVM.BitCode.BitString (
-    BitString(..)
+    BitString(BitString)
   , toBitString
   , showBitString
   , fromBitString
+  , bitStringValue
   , maskBits
   , take, drop
   ) where
@@ -32,6 +33,9 @@ instance Monoid BitString where
 -- | Given a number of bits to take, and an @Integer@, create a @BitString@.
 toBitString :: Int -> Integer -> BitString
 toBitString len val = BitString len (val .&. maskBits len)
+
+bitStringValue :: BitString -> Integer
+bitStringValue = bsData
 
 fromBitString :: (Num a, Bits a) => BitString -> a
 fromBitString (BitString l i) =

--- a/src/Data/LLVM/BitCode/Bitstream.hs
+++ b/src/Data/LLVM/BitCode/Bitstream.hs
@@ -34,24 +34,13 @@ import Data.Tuple.Extra (thd3)
 
 -- | Parse a @Bool@ out of a single bit.
 boolean :: GetBits Bool
-boolean  = do
-  bs <- fixed 1
-  return (bsData bs == 1)
+boolean  = ((1 :: Word8) ==) . fromBitString <$> fixed 1
+
 
 -- | Parse a Num type out of n-bits.
 numeric :: (Num a, Bits a) => Int -> GetBits a
-numeric n = do
-  bs <- fixed n
-  let x = fromIntegral (bsData bs)
-  case bitSizeMaybe x of
-    Nothing -> return x
-    Just n'
-      | bsData bs < bit n' -> return x
-      | otherwise -> fail $ unwords
-           [ "Data.LLVM.BitCode.numeric: bitstring value of length", show n
-           , "( " ++ show (bsData bs) ++ ")"
-           , "could not be parsed into type with only", show n', "bits"
-           ]
+numeric n = fromBitString <$> fixed n
+
 
 -- | Get a @BitString@ formatted as vbr.
 vbr :: Int -> GetBits BitString

--- a/src/Data/LLVM/BitCode/Bitstream.hs
+++ b/src/Data/LLVM/BitCode/Bitstream.hs
@@ -34,19 +34,19 @@ import Data.Tuple.Extra (thd3)
 
 -- | Parse a @Bool@ out of a single bit.
 boolean :: GetBits Bool
-boolean  = ((1 :: Word8) ==) . fromBitString <$> fixed 1
+boolean  = ((1 :: Word8) ==) . fromBitString <$> fixed (Bits' 1)
 
 
 -- | Parse a Num type out of n-bits.
-numeric :: (Num a, Bits a) => Int -> GetBits a
+numeric :: (Num a, Bits a) => NumBits -> GetBits a
 numeric n = fromBitString <$> fixed n
 
 
 -- | Get a @BitString@ formatted as vbr.
-vbr :: Int -> GetBits BitString
+vbr :: NumBits -> GetBits BitString
 vbr n = loop mempty
   where
-  len      = n - 1
+  len      = subtractBitCounts n (Bits' 1)
   loop acc = acc `seq` do
     chunk <- fixed len
     cont  <- boolean
@@ -56,13 +56,13 @@ vbr n = loop mempty
        else return acc'
 
 -- | Process a variable-bit encoded integer.
-vbrNum :: (Num a, Bits a) => Int -> GetBits a
+vbrNum :: (Num a, Bits a) => NumBits -> GetBits a
 vbrNum n = fromBitString <$> vbr n
 
 -- | Decode a 6-bit encoded character.
 char6 :: GetBits Word8
 char6  = do
-  word <- numeric 6
+  word <- numeric $ Bits' 6
   case word of
     n | 0  <= n && n <= 25 -> return (n + 97)
       | 26 <= n && n <= 51 -> return (n + 39)
@@ -92,7 +92,7 @@ parseBitCodeBitstreamLazy = bimap thd3 thd3 . BG.runGetOrFail (runGetBits getBit
 
 -- | The magic constant at the beginning of all llvm-bitcode files.
 bcMagicConst :: BitString
-bcMagicConst  = BitString 8 0x42 `mappend` BitString 8 0x43
+bcMagicConst  = BitString (Bits' 8) 0x42 `mappend` BitString (Bits' 8) 0x43
 
 -- | Parse a @Bitstream@ from either a normal bitcode file, or a wrapped
 -- bitcode.
@@ -102,31 +102,31 @@ getBitCodeBitstream  = label "llvm-bitstream" $ do
   case mb of
     Nothing -> getBitstream
     Just () -> do
-      skip 32 -- Version
-      off <- fixed 32
+      skip $ Bits' 32 -- Version
+      off <- fixed $ Bits' 32
       -- the offset should always be 20 (5 word32 values)
       unless (fromBitString off == (20 :: Int))
           (fail ("invalid offset value: " ++ show off))
-      size <- fixed 32
-      skip 32 -- CPUType
+      size <- fixed $ Bits' 32
+      skip $ Bits' 32 -- CPUType
       isolate (fromBitString size `div` 4) getBitstream
 
 bcWrapperMagicConst :: BitString
 bcWrapperMagicConst  = mconcat [byte 0xDE, byte 0xC0, byte 0x17, byte 0x0B]
   where
-  byte = BitString 8
+  byte = BitString (Bits' 8)
 
 guardWrapperMagic :: GetBits ()
 guardWrapperMagic  = do
-  magic <- fixed 32
+  magic <- fixed (Bits' 32)
   guard (magic == bcWrapperMagicConst)
 
 -- | Parse a @Bitstream@.
 getBitstream :: GetBits Bitstream
 getBitstream  = label "bitstream" $ do
-  bc       <- fixed 16
+  bc       <- fixed $ Bits' 16
   unless (bc == bcMagicConst) (fail "Invalid magic number")
-  appMagic <- numeric 16
+  appMagic <- numeric $ Bits' 16
   entries  <- getTopLevelEntries
   return Bitstream
     { bsAppMagic = appMagic
@@ -142,7 +142,7 @@ data Entry
 
 -- | Parse top-level entries.
 getTopLevelEntries :: GetBits [Entry]
-getTopLevelEntries  = fst <$> getEntries 2 Map.empty emptyAbbrevMap True
+getTopLevelEntries  = fst <$> getEntries (Bits' 2) Map.empty emptyAbbrevMap True
 
 -- | Get as many entries as we can parse.
 getEntries :: AbbrevIdWidth -> BlockInfoMap -> AbbrevMap -> Bool
@@ -184,7 +184,7 @@ getEntries aw bim0 am0 endBlocksFail = loop bim0 am0
 
 -- Abbreviation IDs ------------------------------------------------------------
 
-type AbbrevIdWidth = Int
+type AbbrevIdWidth = NumBits
 
 data AbbrevId
   = END_BLOCK
@@ -215,12 +215,12 @@ data DefineAbbrev = DefineAbbrev
 -- | Parse an abbreviation definition.
 getDefineAbbrev :: GetBits DefineAbbrev
 getDefineAbbrev  =
-  label "define abbrev" (DefineAbbrev `fmap` (getAbbrevOps =<< vbrNum 5))
+  label "define abbrev" (DefineAbbrev `fmap` (getAbbrevOps =<< vbrNum (Bits' 5)))
 
 data AbbrevOp
   = OpLiteral !BitString
-  | OpFixed   !Int
-  | OpVBR     !Int
+  | OpFixed   !NumBits
+  | OpVBR     !NumBits
   | OpArray    AbbrevOp
   | OpChar6
   | OpBlob
@@ -240,12 +240,12 @@ getAbbrevOp  = label "abbrevop" $ do
   let one = fmap (\x -> (x,1))
   isLiteral <- boolean
   if isLiteral
-     then one (OpLiteral <$> vbr 8)
+     then one (OpLiteral <$> (vbr $ Bits' 8))
      else do
-       enc <- numeric 3
+       enc <- numeric $ Bits' 3
        case enc :: Word8 of
-         1 -> one (OpFixed <$> vbrNum 5)
-         2 -> one (OpVBR   <$> vbrNum 5)
+         1 -> one (OpFixed . Bits' <$> vbrNum (Bits' 5))
+         2 -> one (OpVBR   . Bits' <$> vbrNum (Bits' 5))
          3 -> do
            (op,n) <- getAbbrevOp
            return (OpArray op, n+1)
@@ -305,10 +305,10 @@ getBlock bim = do
 -- | A generic block.
 getGenericBlock :: BlockInfoMap -> GetBits (Block,BlockInfoMap)
 getGenericBlock bim = label "block " $ do
-  blockid      <- vbrNum 8
-  newabbrevlen <- vbrNum 4
+  blockid      <- vbrNum $ Bits' 8
+  newabbrevlen <- Bits' <$> (vbrNum $ Bits' 4)
   align32bits
-  blocklen     <- numeric 32
+  blocklen     <- numeric $ Bits' 32
   let am = lookupAbbrevMap blockid bim
   (entries,bim') <- isolate blocklen (getEntries newabbrevlen bim am False)
   let block = Block
@@ -375,9 +375,9 @@ data UnabbrevRecord = UnabbrevRecord
 -- | Parse an unabbreviated record.
 getUnabbrevRecord :: GetBits UnabbrevRecord
 getUnabbrevRecord  = label "unabbreviated record" $ do
-  code   <- vbrNum 6
-  numops <- vbrNum 6
-  ops    <- replicateM numops (vbr 6)
+  code   <- vbrNum $ Bits' 6
+  numops <- vbrNum $ Bits' 6
+  ops    <- replicateM numops (vbr $ Bits' 6)
   return UnabbrevRecord
     { unabbrevCode = code
     , unabbrevOps  = ops
@@ -431,13 +431,13 @@ interpAbbrevOp op = label (show op) $ case op of
   OpVBR width -> FieldVBR <$> vbr width
 
   OpArray ty -> do
-    len <- vbrNum 6
+    len <- vbrNum $ Bits' 6
     FieldArray <$> replicateM len (interpAbbrevOp ty)
 
   OpChar6 -> FieldChar6 <$> char6
 
   OpBlob -> do
-    len   <- vbrNum 6
+    len   <- Bytes' <$> (vbrNum $ Bits' 6)
     bytes <- bytestring len
     return (FieldBlob bytes)
 
@@ -447,5 +447,5 @@ interpAbbrevOp op = label (show op) $ case op of
 parseMetadataStringLengths :: Int -> S.ByteString -> Either String [Int]
 parseMetadataStringLengths n =
   bimap thd3 thd3
-  . BG.runGetOrFail (runGetBits (replicateM n (vbrNum 6)))
+  . BG.runGetOrFail (runGetBits (replicateM n (vbrNum $ Bits' 6)))
   . L.fromStrict

--- a/src/Data/LLVM/BitCode/GetBits.hs
+++ b/src/Data/LLVM/BitCode/GetBits.hs
@@ -88,33 +88,35 @@ instance MonadPlus GetBits where
 -- given the use of 32-bit padding already, it seems likely that all bitcode
 -- files get padded to a 32-bit boundary.
 data SubWord
-  = SubWord !Int !Word32
+  = SubWord !NumBits !Word32
     deriving (Show)
 
 aligned :: SubWord
-aligned = SubWord 0 0
+aligned = SubWord (Bits' 0) 0
 
-splitWord :: Int -> SubWord -> (BitString, Either Int SubWord)
+splitWord :: NumBits -> SubWord -> (BitString, Either NumBits SubWord)
 splitWord n (SubWord l w)
-  | n <= l    = (toBitString n (fromIntegral w), Right (SubWord (l - n) (w `shiftR` n)))
-  | otherwise = (toBitString l (fromIntegral w), Left (n - l))
+  | n <= l = ( toBitString n (fromIntegral w)
+             , Right (SubWord (subtractBitCounts l n) (w `shiftR` bitCount n))
+             )
+  | otherwise = (toBitString l (fromIntegral w), Left (subtractBitCounts n l))
 
 -- | @getBitString n@ grabs a @BitString@ of length @n@ from the next incoming
 -- word, yielding the remainder partial word.  On @n@ = @0@, it does not
 -- actually consume the next word.  Should not be called to read more than one
 -- 32-bit word at a time (will fail on @n@ > 32).
-getBitString :: Int -> BG.Get (BitString, SubWord)
-getBitString 0 = return (mempty, aligned)
-getBitString n | n > 32 =
+getBitString :: NumBits -> BG.Get (BitString, SubWord)
+getBitString (Bits' 0) = return (mempty, aligned)
+getBitString n | n > (Bits' 32) =
   fail $ "getBitString: refusing to read " ++ show n ++ " (> 32) bits."
-getBitString n = getBitStringPartial n . SubWord 32 =<< BG.getWord32le
+getBitString n = getBitStringPartial n . SubWord (Bits' 32) =<< BG.getWord32le
 
 -- | @getBitStringPartial n sw@ returns a @BitString@ of length @n@ from either
 -- the current subword @sw@ (with some @l@ bits available), potentially also
 -- reading the next incoming word if @n@ > @l@.  Should not be called to read
 -- more than one 32-bit word at a time (will fail on @n@ > 32).
-getBitStringPartial :: Int -> SubWord -> BG.Get (BitString, SubWord)
-getBitStringPartial n _ | n > 32 =
+getBitStringPartial :: NumBits -> SubWord -> BG.Get (BitString, SubWord)
+getBitStringPartial n _ | n > (Bits' 32) =
   fail $ "getBitStringPartial: refusing to read " ++ show n ++ " (> 32) bits."
 getBitStringPartial n sw = case splitWord n sw of
   (bs, Right off) -> return (bs, off)
@@ -129,8 +131,8 @@ skipZeroByte = do
   when (x /= 0) $ fail "alignment padding was not zeros"
 
 -- | Get a @ByteString@ of @n@ bytes, and then align to 32 bits.
-getByteString :: Int -> BG.Get (ByteString, SubWord)
-getByteString n = do
+getByteString :: NumBytes -> BG.Get (ByteString, SubWord)
+getByteString (Bytes' n) = do
   bs <- BG.getByteString n
   replicateM_ ((- n) `mod` 4) skipZeroByte
   return (bs, aligned)
@@ -145,11 +147,11 @@ align32bits  = GetBits $ \ off -> case off of
   SubWord _ _ -> fail "alignment padding was not zeros"
 
 -- | Read out n bits as a @BitString@.
-fixed :: Int -> GetBits BitString
+fixed :: NumBits -> GetBits BitString
 fixed n = GetBits $ getBitStringPartial n
 
 -- | Read out n bytes as a @ByteString@, aligning to a 32-bit boundary before and after.
-bytestring :: Int -> GetBits ByteString
+bytestring :: NumBytes -> GetBits ByteString
 bytestring n = GetBits $ \ off -> case off of
   SubWord _ 0 -> getByteString n
   SubWord _ _ -> fail "alignment padding was not zeros"
@@ -169,7 +171,7 @@ isolate ws m = GetBits (BG.isolate (ws * 4) . unGetBits m)
 try :: GetBits a -> GetBits (Maybe a)
 try m = (Just <$> m) `mplus` return Nothing
 
-skip :: Int -> GetBits ()
+skip :: NumBits -> GetBits ()
 skip n = do
   _ <- fixed n
   return ()

--- a/src/Data/LLVM/BitCode/GetBits.hs
+++ b/src/Data/LLVM/BitCode/GetBits.hs
@@ -107,7 +107,7 @@ splitWord n (SubWord l w)
 -- 32-bit word at a time (will fail on @n@ > 32).
 getBitString :: NumBits -> BG.Get (BitString, SubWord)
 getBitString (Bits' 0) = return (mempty, aligned)
-getBitString n | n > (Bits' 32) =
+getBitString n | n > Bits' 32 =
   fail $ "getBitString: refusing to read " ++ show n ++ " (> 32) bits."
 getBitString n = getBitStringPartial n . SubWord (Bits' 32) =<< BG.getWord32le
 
@@ -116,7 +116,7 @@ getBitString n = getBitStringPartial n . SubWord (Bits' 32) =<< BG.getWord32le
 -- reading the next incoming word if @n@ > @l@.  Should not be called to read
 -- more than one 32-bit word at a time (will fail on @n@ > 32).
 getBitStringPartial :: NumBits -> SubWord -> BG.Get (BitString, SubWord)
-getBitStringPartial n _ | n > (Bits' 32) =
+getBitStringPartial n _ | n > Bits' 32 =
   fail $ "getBitStringPartial: refusing to read " ++ show n ++ " (> 32) bits."
 getBitStringPartial n sw = case splitWord n sw of
   (bs, Right off) -> return (bs, off)

--- a/src/Data/LLVM/BitCode/GetBits.hs
+++ b/src/Data/LLVM/BitCode/GetBits.hs
@@ -160,9 +160,9 @@ bytestring n = GetBits $ \ off -> case off of
 label :: String -> GetBits a -> GetBits a
 label l m = GetBits (BG.label l . unGetBits m)
 
--- | Isolate input length, in 32-bit words.
-isolate :: Int -> GetBits a -> GetBits a
-isolate ws m = GetBits (BG.isolate (ws * 4) . unGetBits m)
+-- | Isolate input to a sub-span of the specified byte length.
+isolate :: NumBytes -> GetBits a -> GetBits a
+isolate (Bytes' ws) m = GetBits (BG.isolate ws . unGetBits m)
 
 -- | Try to parse something, returning Nothing when it fails.
 --

--- a/src/Data/LLVM/BitCode/IR.hs
+++ b/src/Data/LLVM/BitCode/IR.hs
@@ -21,7 +21,9 @@ import Data.Word (Word16)
 
 -- | The magic number that identifies a @Bitstream@ structure as LLVM IR.
 llvmIrMagic :: Word16
-llvmIrMagic  = fromBitString (toBitString 8 0xc0 `mappend` toBitString 8 0xde)
+llvmIrMagic  = fromBitString (toBitString (Bits' 8) 0xc0
+                              `mappend`
+                              toBitString (Bits' 8) 0xde)
 
 -- | Parse an LLVM Module out of a Bitstream object.
 parseModule :: Bitstream -> Parse Module

--- a/src/Data/LLVM/BitCode/IR/Constants.hs
+++ b/src/Data/LLVM/BitCode/IR/Constants.hs
@@ -1,7 +1,8 @@
-{-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Data.LLVM.BitCode.IR.Constants where
 
@@ -18,6 +19,7 @@ import           Control.Monad (mplus,mzero,foldM,(<=<), when)
 import           Control.Monad.ST (runST,ST)
 import           Data.Array.ST (newArray,readArray,MArray,STUArray)
 import           Data.Bits (shiftL,shiftR,testBit, Bits)
+import           Data.LLVM.BitCode.BitString ( pattern Bits' )
 import qualified Data.LLVM.BitCode.BitString as BitS
 import qualified Data.Map as Map
 import           Data.Maybe (fromMaybe, isJust)
@@ -539,11 +541,11 @@ fp80build ty r cs getTy =
   do v1 <- parseField r 0 fieldLiteral
      v2 <- parseField r 1 fieldLiteral
      let -- Note bs1 <> bs2 results in bs2|bs1 layout, shifting bs2 to higher bits
-         v64_0 = BitS.take 64 (BitS.take 16 v2 <> v1)
-         v64_1 = BitS.drop 48 v2
+         v64_0 = BitS.take (Bits' 64) (BitS.take (Bits' 16) v2 <> v1)
+         v64_1 = BitS.drop (Bits' 48) v2
          -- result is v64_1|v64_0 being v0|v1
          fullexp :: Word16
-         fullexp = BitS.fromBitString $ BitS.take 16 v64_1 -- includes sign bit
+         fullexp = BitS.fromBitString $ BitS.take (Bits' 16) v64_1 -- includes sign bit
          significnd :: Word64
          significnd = BitS.fromBitString $ v64_0
          fp80Val = FP80_LongDouble fullexp significnd

--- a/src/Data/LLVM/BitCode/Record.hs
+++ b/src/Data/LLVM/BitCode/Record.hs
@@ -145,17 +145,17 @@ unsigned  = numeric
 boolean :: Match Field Bool
 boolean  = decode <=< (fieldFixed ||| fieldLiteral ||| fieldVbr)
   where
-  decode bs
-    | bsData bs == 1 = return True
-    | bsData bs == 0 = return False
-    | otherwise      = mzero
+  decode bs = case bitStringValue bs of
+                0 -> return False
+                1 -> return True
+                _ -> mzero
 
 nonzero :: Match Field Bool
 nonzero  = decode <=< (fieldFixed ||| fieldLiteral ||| fieldVbr)
   where
-  decode bs
-    | bsData bs == 0 = return False
-    | otherwise      = return True
+  decode bs = return $ case bitStringValue bs of
+                         0 -> False
+                         _ -> True
 
 char :: Match Field Word8
 char = numeric


### PR DESCRIPTION
This makes various modifications to BitString to clarify the usage, intent, and API, and to minimize that API.

Notably:
* `Int` was used for counts of both Bits and Bytes, so a newtype for each is introduced to clarify intent.
* Functions to access and manipulate the BitString are used universally to allow the internals to be decoupled from the interface.

This work is creating a basis for subsequent work on performance and memory footprint.