### PR TITLE
Explicit BitString interface and removal of internal SubWord

### DIFF
--- a/llvm-pretty-bc-parser.cabal
+++ b/llvm-pretty-bc-parser.cabal
@@ -62,7 +62,6 @@ Library
                        binary      >= 0.8,
                        bytestring  >= 0.10,
                        containers  >= 0.4,
-                       extra       >= 1.7,
                        fgl         >= 5.5,
                        llvm-pretty >= 0.11 && < 0.12,
                        mtl         >= 2.2.2,

--- a/src/Data/LLVM/BitCode/BitString.hs
+++ b/src/Data/LLVM/BitCode/BitString.hs
@@ -11,7 +11,7 @@ module Data.LLVM.BitCode.BitString
   , take, drop
   , joinBitString
   , NumBits, NumBytes, pattern Bits', pattern Bytes'
-  , bitCount
+  , bitCount, bitsToBytes, bytesToBits
   , addBitCounts
   , subtractBitCounts
   )
@@ -40,15 +40,19 @@ pattern Bytes' n = NumBytes n
 bitCount :: NumBits -> Int
 bitCount (NumBits n) = n
 
+{-# INLINE addBitCounts #-}
 addBitCounts :: NumBits -> NumBits -> NumBits
 addBitCounts (NumBits a) (NumBits b) = NumBits $ a + b
 
+{-# INLINE subtractBitCounts #-}
 subtractBitCounts :: NumBits -> NumBits -> NumBits
 subtractBitCounts (NumBits a) (NumBits b) = NumBits $ a - b
 
+{-# INLINE bytesToBits #-}
 bitsToBytes :: NumBits -> (NumBytes, NumBits)
 bitsToBytes (NumBits n) = (NumBytes $ n `shiftR` 3, NumBits $ n .&. 7)
 
+{-# INLINE bitsToBytes #-}
 bytesToBits :: NumBytes -> NumBits
 bytesToBits (NumBytes n) = NumBits $ n `shiftL` 3
 

--- a/src/Data/LLVM/BitCode/BitString.hs
+++ b/src/Data/LLVM/BitCode/BitString.hs
@@ -23,6 +23,8 @@ import Numeric (showIntAtBase)
 import Prelude hiding (take,drop,splitAt)
 
 ----------------------------------------------------------------------
+-- Define some convenience newtypes to clarify whether the count of bits or count
+-- of bytes is being referenced, and to convert between the two.
 
 newtype NumBits = NumBits Int deriving (Show, Eq, Ord)
 newtype NumBytes = NumBytes Int deriving (Show, Eq, Ord)
@@ -43,6 +45,14 @@ addBitCounts (NumBits a) (NumBits b) = NumBits $ a + b
 
 subtractBitCounts :: NumBits -> NumBits -> NumBits
 subtractBitCounts (NumBits a) (NumBits b) = NumBits $ a - b
+
+bitsToBytes :: NumBits -> (NumBytes, NumBits)
+bitsToBytes (NumBits n) = (NumBytes $ n `shiftR` 3, NumBits $ n .&. 7)
+
+bytesToBits :: NumBytes -> NumBits
+bytesToBits (NumBytes n) = NumBits $ n `shiftL` 3
+
+----------------------------------------------------------------------
 
 data BitString = BitString
   { bsLength :: !NumBits

--- a/src/Data/LLVM/BitCode/BitString.hs
+++ b/src/Data/LLVM/BitCode/BitString.hs
@@ -2,7 +2,7 @@
 
 module Data.LLVM.BitCode.BitString
   (
-    BitString(BitString)
+    BitString
   , emptyBitString
   , toBitString
   , showBitString

--- a/src/Data/LLVM/BitCode/BitString.hs
+++ b/src/Data/LLVM/BitCode/BitString.hs
@@ -70,7 +70,7 @@ emptyBitString = BitString (NumBits 0) 0
 
 
 -- | Join two BitString representations together to form a single larger
--- BitString.  The first BitString is the "lower" value portion of the resulting
+-- BitString.  The first BitString is the \"lower\" value portion of the resulting
 -- BitString.
 
 joinBitString :: BitString -> BitString -> BitString
@@ -130,8 +130,7 @@ maskBits (NumBits len)
 
 
 -- | Extract a smaller BitString with the specified number of bits from the
--- "start" of a larger BitString.
-
+-- \"start\" of a larger BitString.
 take :: NumBits -> BitString -> BitString
 take n bs@(BitString l i)
   | n >= l    = bs

--- a/src/Data/LLVM/BitCode/Bitstream.hs
+++ b/src/Data/LLVM/BitCode/Bitstream.hs
@@ -16,18 +16,15 @@ module Data.LLVM.BitCode.Bitstream (
   , parseMetadataStringLengths
   ) where
 
-import Data.LLVM.BitCode.BitString as BS
-import Data.LLVM.BitCode.GetBits
+import           Data.LLVM.BitCode.BitString as BS
+import           Data.LLVM.BitCode.GetBits
 
-import Control.Monad (unless,replicateM,guard)
-import Data.Bits (Bits, bitSizeMaybe, bit)
-import Data.Word (Word8,Word16,Word32)
-import qualified Data.Binary.Get as BG
+import           Control.Monad ( unless, replicateM, guard )
+import           Data.Bits ( Bits )
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
 import qualified Data.Map as Map
-import Data.Bifunctor (bimap)
-import Data.Tuple.Extra (thd3)
+import           Data.Word ( Word8, Word16, Word32 )
 
 
 -- Primitive Reads -------------------------------------------------------------
@@ -80,15 +77,13 @@ data Bitstream = Bitstream
   } deriving (Show)
 
 parseBitstream :: S.ByteString -> Either String Bitstream
-parseBitstream = bimap thd3 thd3
-                 . BG.runGetOrFail (runGetBits getBitstream)
-                 . L.fromStrict
+parseBitstream = runGetBits getBitstream
 
 parseBitCodeBitstream :: S.ByteString -> Either String Bitstream
 parseBitCodeBitstream = parseBitCodeBitstreamLazy . L.fromStrict
 
 parseBitCodeBitstreamLazy :: L.ByteString -> Either String Bitstream
-parseBitCodeBitstreamLazy = bimap thd3 thd3 . BG.runGetOrFail (runGetBits getBitCodeBitstream)
+parseBitCodeBitstreamLazy = runGetBits getBitCodeBitstream . L.toStrict
 
 -- | The magic constant at the beginning of all llvm-bitcode files.
 bcMagicConst :: BitString
@@ -450,7 +445,4 @@ interpAbbrevOp op = label (show op) $ case op of
 -- Metadata String Lengths -----------------------------------------------------
 
 parseMetadataStringLengths :: Int -> S.ByteString -> Either String [Int]
-parseMetadataStringLengths n =
-  bimap thd3 thd3
-  . BG.runGetOrFail (runGetBits (replicateM n (vbrNum $ Bits' 6)))
-  . L.fromStrict
+parseMetadataStringLengths n = runGetBits (replicateM n (vbrNum $ Bits' 6))

--- a/src/Data/LLVM/BitCode/Bitstream.hs
+++ b/src/Data/LLVM/BitCode/Bitstream.hs
@@ -87,9 +87,9 @@ parseBitCodeBitstreamLazy = runGetBits getBitCodeBitstream . L.toStrict
 
 -- | The magic constant at the beginning of all llvm-bitcode files.
 bcMagicConst :: BitString
-bcMagicConst  = BitString (Bits' 8) 0x42
+bcMagicConst  = toBitString (Bits' 8) 0x42
                 `joinBitString`
-                BitString (Bits' 8) 0x43
+                toBitString (Bits' 8) 0x43
 
 -- | Parse a @Bitstream@ from either a normal bitcode file, or a wrapped
 -- bitcode.
@@ -112,7 +112,7 @@ bcWrapperMagicConst :: BitString
 bcWrapperMagicConst  =
   foldr1 joinBitString [ byte 0xDE, byte 0xC0, byte 0x17, byte 0x0B]
   where
-  byte = BitString (Bits' 8)
+  byte = toBitString (Bits' 8)
 
 guardWrapperMagic :: GetBits ()
 guardWrapperMagic  = do

--- a/src/Data/LLVM/BitCode/GetBits.hs
+++ b/src/Data/LLVM/BitCode/GetBits.hs
@@ -11,68 +11,106 @@ module Data.LLVM.BitCode.GetBits (
   , skip
   ) where
 
-import Data.LLVM.BitCode.BitString
+import           Data.LLVM.BitCode.BitString
 
-import Control.Applicative (Alternative(..))
-import Control.Arrow (first)
-import Control.Monad (MonadPlus(..),when,replicateM_)
-import qualified Data.Binary.Get as BG
-import Data.Bits (shiftR)
-import Data.ByteString (ByteString)
-import Data.Word (Word32)
+import           Control.Applicative ( Alternative(..) )
+import           Control.Monad ( MonadPlus(..) )
+import           Data.Bits ( (.&.), (.|.), shiftL, shiftR )
+import           Data.ByteString ( ByteString )
+import qualified Data.ByteString as BS
 
 #if !MIN_VERSION_base(4,13,0)
-import Control.Monad.Fail( MonadFail )
+import           Control.Monad.Fail ( MonadFail )
 import qualified Control.Monad.Fail
 #endif
 
 -- Bit-level Parsing -----------------------------------------------------------
 
-newtype GetBits a = GetBits { unGetBits :: SubWord -> BG.Get (a,SubWord) }
+newtype GetBits a = GetBits { unGetBits :: Either String (BitPosition -> BS.ByteString -> (BitsGetter a, BitPosition)) } -- Left is outer fail
+
+newtype BitPosition = BitPosition (NumBits, NumBits) -- (current, limit)
+
+type BitsGetter a = BS.ByteString -> Either String a -- Left is inner fail
+
 
 -- | Run a @GetBits@ action, returning its value, and the number of bits offset
 -- into the next byte of the stream.
-runGetBits :: GetBits a -> BG.Get a
-runGetBits m = fst `fmap` unGetBits m aligned
+runGetBits :: GetBits a -> ByteString -> Either String a
+runGetBits m bs =
+  let startPos = BitPosition ( Bits' 0
+                             , bytesToBits $ Bytes' $ BS.length bs
+                             )
+  in ($ bs) =<< (fst . ($ bs) . ($ startPos) <$> unGetBits m)
+
 
 instance Functor GetBits where
   {-# INLINE fmap #-}
-  fmap f m = GetBits (\ off -> first f <$> unGetBits m off)
+  fmap f m = GetBits $ case unGetBits m of
+    Left e -> Left e
+    Right g -> Right $ \pos inp -> let (b,n) = g pos inp
+                                   in (\bs -> f <$> b bs, n)
 
 instance Applicative GetBits where
   {-# INLINE pure #-}
-  pure x = GetBits (\ off -> return (x,off))
+  pure x = GetBits $ pure $ \pos _ -> (const $ pure x, pos)
 
   {-# INLINE (<*>) #-}
-  f <*> x = GetBits $ \ off0 -> do
-    (g,off1) <- unGetBits f off0
-    (y,off2) <- unGetBits x off1
-    return (g y,off2)
+  f <*> x =
+    GetBits $ do k <- unGetBits f
+                 l <- unGetBits x
+                 return $ \pos inp -> let (g,n) = k pos inp
+                                          (y,m) = l n inp
+                                          in ( \_ -> do g' <- g inp
+                                                        y' <- y inp
+                                                        return $ g' y'
+                                             , m
+                                             )
 
 instance Monad GetBits where
   {-# INLINE return #-}
   return = pure
 
   {-# INLINE (>>=) #-}
-  m >>= f = GetBits $ \ off0 -> do
-    (x,off1) <- unGetBits m off0
-    unGetBits (f x) off1
+  m >>= f =
+    case unGetBits m of
+      Left e -> GetBits $ Left e
+      Right k -> GetBits $ pure $ \pos inp ->
+        let (g,n) = k pos inp
+            (gr,nr) = case g inp of  -- KWQ: this is weak, assumes bs == inp
+              Left e -> (Left e, n)
+              Right a -> case unGetBits $ f a of
+                Left e -> (Left e, n)
+                Right l -> let (h,x) = l n inp
+                           in (h inp, x)
+        in (const gr, nr)
 
 #if !MIN_VERSION_base(4,13,0)
   {-# INLINE fail #-}
-  fail str = GetBits (\ _ -> fail str)
+  fail = GetBits . Left
 #endif
 
 instance MonadFail GetBits where
   {-# INLINE fail #-}
-  fail str = GetBits (\ _ -> fail str)
+  fail = GetBits . Left
 
 instance Alternative GetBits where
   {-# INLINE empty #-}
-  empty   = GetBits (\_ -> mzero)
+  empty   = GetBits $ Left "GetBits is empty!"
 
   {-# INLINE (<|>) #-}
-  a <|> b = GetBits (\ off -> unGetBits a off <|> unGetBits b off)
+  a <|> b = GetBits
+            $ case unGetBits a of
+                Right k ->
+                  Right $ \pos inp ->
+                            let (g,n) = k pos inp
+                                (gr,nr) = case g inp of
+                                  Right x -> (Right x, n)
+                                  Left _ -> case unGetBits b of
+                                    Left e -> (Left e, n)
+                                    Right l -> let (h,m) = l pos inp
+                                               in (h inp, m)
+                            in (const gr, nr)
+                Left _ -> unGetBits b
 
 instance MonadPlus GetBits where
   {-# INLINE mzero #-}
@@ -82,96 +120,120 @@ instance MonadPlus GetBits where
   mplus = (<|>)
 
 
--- Sub-word Bit Parsing State --------------------------------------------------
+-- | Extracts an Integer value of the specified number of bits from a ByteString,
+-- starting at the indicated bit position (fails with Left if the range to
+-- extract is not valid... i.e. > bitLimit).  Returns the Integer value along
+-- with the bit position following the extraction.
 
--- This assumes that we'll pad any incoming bitcode to a 32-bit boundary, but
--- given the use of 32-bit padding already, it seems likely that all bitcode
--- files get padded to a 32-bit boundary.
-data SubWord
-  = SubWord !NumBits !Word32
-    deriving (Show)
-
-aligned :: SubWord
-aligned = SubWord (Bits' 0) 0
-
-splitWord :: NumBits -> SubWord -> (BitString, Either NumBits SubWord)
-splitWord n (SubWord l w)
-  | n <= l = ( toBitString n (fromIntegral w)
-             , Right (SubWord (subtractBitCounts l n) (w `shiftR` bitCount n))
-             )
-  | otherwise = (toBitString l (fromIntegral w), Left (subtractBitCounts n l))
-
--- | @getBitString n@ grabs a @BitString@ of length @n@ from the next incoming
--- word, yielding the remainder partial word.  On @n@ = @0@, it does not
--- actually consume the next word.  Should not be called to read more than one
--- 32-bit word at a time (will fail on @n@ > 32).
-getBitString :: NumBits -> BG.Get (BitString, SubWord)
-getBitString (Bits' 0) = return (emptyBitString, aligned)
-getBitString n | n > Bits' 32 =
-  fail $ "getBitString: refusing to read " ++ show n ++ " (> 32) bits."
-getBitString n = getBitStringPartial n . SubWord (Bits' 32) =<< BG.getWord32le
-
--- | @getBitStringPartial n sw@ returns a @BitString@ of length @n@ from either
--- the current subword @sw@ (with some @l@ bits available), potentially also
--- reading the next incoming word if @n@ > @l@.  Should not be called to read
--- more than one 32-bit word at a time (will fail on @n@ > 32).
-getBitStringPartial :: NumBits -> SubWord -> BG.Get (BitString, SubWord)
-getBitStringPartial n _ | n > Bits' 32 =
-  fail $ "getBitStringPartial: refusing to read " ++ show n ++ " (> 32) bits."
-getBitStringPartial n sw = case splitWord n sw of
-  (bs, Right off) -> return (bs, off)
-  (bs, Left n') -> do
-    (rest, off) <- getBitString n'
-    return (bs `joinBitString` rest, off)
-
--- | Skip a byte of input, which must be zero.
-skipZeroByte :: BG.Get ()
-skipZeroByte = do
-  x <- BG.getWord8
-  when (x /= 0) $ fail "alignment padding was not zeros"
-
--- | Get a @ByteString@ of @n@ bytes, and then align to 32 bits.
-getByteString :: NumBytes -> BG.Get (ByteString, SubWord)
-getByteString (Bytes' n) = do
-  bs <- BG.getByteString n
-  replicateM_ ((- n) `mod` 4) skipZeroByte
-  return (bs, aligned)
+extractFromByteString :: NumBits -> NumBits -> NumBits -> ByteString
+                      -> Either String (Integer, NumBits)
+extractFromByteString bitLimit startBit numBits bs =
+  let Bytes' s8 = fst (bitsToBytes startBit)
+      Bytes' r8 = fst (bitsToBytes numBits)
+      rcnt = r8 + 2 -- 2 == pre-shift overflow byte on either side
+      ws = BS.take rcnt $ BS.drop s8 bs
+      wi = BS.foldr (\w a -> a `shiftL` 8 .|. fromIntegral w) (0::Integer) ws
+      mask = ((1::Integer) `shiftL` bitCount numBits) - 1
+      vi = wi `shiftR` (bitCount startBit .&. 7) .&. mask
+      updPos = addBitCounts startBit numBits
+  in if updPos > bitLimit
+     then Left ("Attempt to read bits past limit (newPos="
+                <> show updPos <> ", limit=" <> show bitLimit <> ")"
+               )
+     else Right (vi, updPos)
 
 
 -- Basic Interface -------------------------------------------------------------
 
 -- | Read zeros up to an alignment of 32-bits.
 align32bits :: GetBits ()
-align32bits  = GetBits $ \ off -> case off of
-  SubWord _ 0 -> return ((), aligned)
-  SubWord _ _ -> fail "alignment padding was not zeros"
+align32bits  = GetBits $ pure $ \pos inp ->
+  let BitPosition (curBit, ttlBits) = pos
+      s32 = bitCount curBit .&. (32 - 1)
+      r32 = Bits' $ 32 - s32  -- num bits to reach next 32-bit boundary
+      nonZero = "alignments @" <> show curBit
+                <> " not zeroes up to 32-bit boundary"
+  in if s32 == 0
+     then (const $ Right (), pos)
+     else case extractFromByteString ttlBits curBit r32 inp of
+            Right (vi, newPos) ->
+              if vi == 0
+              then (const $ Right (), BitPosition (newPos, ttlBits))
+              else (const $ Left nonZero, pos)
+            Left e -> (const $ Left e, pos)
+
 
 -- | Read out n bits as a @BitString@.
 fixed :: NumBits -> GetBits BitString
-fixed n = GetBits $ getBitStringPartial n
+fixed n = GetBits $ pure
+          $ \s@(BitPosition (cur,lim)) ->
+              \inp ->
+                case extractFromByteString lim cur n inp of
+                  Right (v,p) -> ( const $ pure $ BitString n v
+                                 , BitPosition (p,lim)
+                                 )
+                  Left e -> (const $ Left e, s)
 
--- | Read out n bytes as a @ByteString@, aligning to a 32-bit boundary before and after.
+
+-- | Read out n bytes as a @ByteString@, aligning to a 32-bit boundary before and
+-- after.
 bytestring :: NumBytes -> GetBits ByteString
-bytestring n = GetBits $ \ off -> case off of
-  SubWord _ 0 -> getByteString n
-  SubWord _ _ -> fail "alignment padding was not zeros"
+bytestring n@(Bytes' nbytes) = do
+  align32bits
+  r <- GetBits $ pure
+       $ \(BitPosition (pos,lim)) ->
+           \inp ->
+             let Bytes' sbyte = fst $ bitsToBytes pos   -- aligned, so snd == 0
+                 endAt = pos `addBitCounts` bytesToBits n
+                 end = BitPosition (endAt, lim)
+                 err = "Sub-bytestring attempted beyond end of input bytestring"
+             in if endAt <= lim
+                then (const $ pure $ BS.take nbytes $ BS.drop sbyte inp, end)
+                else (const $ Left err, end)
+  align32bits
+  return r
+
 
 -- | Add a label to the error tag stack.
 label :: String -> GetBits a -> GetBits a
-label l m = GetBits (BG.label l . unGetBits m)
+label l m = case unGetBits m of
+              Left e -> GetBits $ Left $ e <> "\n  " <> l
+              Right k -> GetBits $ pure
+                         $ \pos inp ->
+                             let (j,n) = k pos inp
+                             in case j inp of
+                                  Left e -> (const $ Left $ e <> "\n  " <> l, n)
+                                  Right r -> (const $ Right r, n)
+
 
 -- | Isolate input to a sub-span of the specified byte length.
 isolate :: NumBytes -> GetBits a -> GetBits a
-isolate (Bytes' ws) m = GetBits (BG.isolate ws . unGetBits m)
+isolate ws m =
+  case unGetBits m of
+    Right k -> GetBits $ pure
+               $ \(BitPosition (pos, lim)) ->
+                   \inp ->
+                     let l = pos `addBitCounts` bytesToBits ws
+                     in let (r,BitPosition (x, _)) = k (BitPosition (pos, l)) inp
+                        in (r, BitPosition (x, lim))
+    Left e -> GetBits $ Left e
+
 
 -- | Try to parse something, returning Nothing when it fails.
---
--- XXX this will hang on to the parsing state at the Get and GetBits levels, so
--- a long-running computation will keep the current state until it finishes.
+
 try :: GetBits a -> GetBits (Maybe a)
 try m = (Just <$> m) `mplus` return Nothing
 
+
+-- | Skips the specified number of bits
+
 skip :: NumBits -> GetBits ()
-skip n = do
-  _ <- fixed n
-  return ()
+skip n = GetBits $ pure
+         $ \(BitPosition (cur,lim)) ->
+             let newLoc = addBitCounts cur n
+                 newPos = BitPosition (newLoc, lim)
+             in if newLoc > lim
+                then const ( const $ Left "skipped past end of bytestring"
+                           , newPos
+                           )
+                else const (const $ Right (), newPos)

--- a/src/Data/LLVM/BitCode/GetBits.hs
+++ b/src/Data/LLVM/BitCode/GetBits.hs
@@ -106,7 +106,7 @@ splitWord n (SubWord l w)
 -- actually consume the next word.  Should not be called to read more than one
 -- 32-bit word at a time (will fail on @n@ > 32).
 getBitString :: NumBits -> BG.Get (BitString, SubWord)
-getBitString (Bits' 0) = return (mempty, aligned)
+getBitString (Bits' 0) = return (emptyBitString, aligned)
 getBitString n | n > Bits' 32 =
   fail $ "getBitString: refusing to read " ++ show n ++ " (> 32) bits."
 getBitString n = getBitStringPartial n . SubWord (Bits' 32) =<< BG.getWord32le
@@ -122,7 +122,7 @@ getBitStringPartial n sw = case splitWord n sw of
   (bs, Right off) -> return (bs, off)
   (bs, Left n') -> do
     (rest, off) <- getBitString n'
-    return (bs `mappend` rest, off)
+    return (bs `joinBitString` rest, off)
 
 -- | Skip a byte of input, which must be zero.
 skipZeroByte :: BG.Get ()

--- a/src/Data/LLVM/BitCode/GetBits.hs
+++ b/src/Data/LLVM/BitCode/GetBits.hs
@@ -169,7 +169,7 @@ fixed n = GetBits $ pure
           $ \s@(BitPosition (cur,lim)) ->
               \inp ->
                 case extractFromByteString lim cur n inp of
-                  Right (v,p) -> ( const $ pure $ BitString n v
+                  Right (v,p) -> ( const $ pure $ toBitString n v
                                  , BitPosition (p,lim)
                                  )
                   Left e -> (const $ Left e, s)

--- a/src/Data/LLVM/BitCode/IR.hs
+++ b/src/Data/LLVM/BitCode/IR.hs
@@ -22,7 +22,7 @@ import Data.Word (Word16)
 -- | The magic number that identifies a @Bitstream@ structure as LLVM IR.
 llvmIrMagic :: Word16
 llvmIrMagic  = fromBitString (toBitString (Bits' 8) 0xc0
-                              `mappend`
+                              `joinBitString`
                               toBitString (Bits' 8) 0xde)
 
 -- | Parse an LLVM Module out of a Bitstream object.

--- a/src/Data/LLVM/BitCode/IR/Constants.hs
+++ b/src/Data/LLVM/BitCode/IR/Constants.hs
@@ -541,7 +541,8 @@ fp80build ty r cs getTy =
   do v1 <- parseField r 0 fieldLiteral
      v2 <- parseField r 1 fieldLiteral
      let -- Note bs1 <> bs2 results in bs2|bs1 layout, shifting bs2 to higher bits
-         v64_0 = BitS.take (Bits' 64) (BitS.take (Bits' 16) v2 <> v1)
+         v64_0 = BitS.take (Bits' 64)
+                 $ BitS.take (Bits' 16) v2 `BitS.joinBitString` v1
          v64_1 = BitS.drop (Bits' 48) v2
          -- result is v64_1|v64_0 being v0|v1
          fullexp :: Word16


### PR DESCRIPTION
This is another step in the work on performance improvements in this parser.  

* This PR makes the `BitString` API more explicit (removing some class interfaces such as `Monoid` and `Semigroup` in favor of explicit functions to clarify the API footprint).  
* Additionally, this refactors the internal implementation for `BitString`.  The previous implementation used `Data.Binary` exclusively to extract a 32-bit integer value from the `ByteString`.  This 32-bit integer was placed into a `SubWord` structure, from which individual bits were extracted until the `SubWord` became "empty", in which case it would be refilled with another 32-bit integer value obtained from `Data.Binary`.  This PR changes the `BitString` to directly keep track of the offset in the underlying `ByteString` (this offset was previously internal to the `Data.Binary` monad), and any value retrievals are performed directly from the `ByteString`, removing the `SubWord` layer of abstraction and manipulation.

A follow-on PR will take additional steps to optimize this implementation.