### PR TITLE
Improve performance and save space by using unlifted types

### DIFF
--- a/llvm-pretty-bc-parser.cabal
+++ b/llvm-pretty-bc-parser.cabal
@@ -75,7 +75,10 @@ Library
 Executable llvm-disasm
   Main-is:             LLVMDis.hs
   Default-language:    Haskell2010
-  Ghc-options:         -Wall -Wunbanged-strict-patterns -O2
+  Ghc-options:         -Wall
+                       -Wunbanged-strict-patterns
+                       -O2
+                       -funbox-strict-fields
   Hs-source-dirs:      llvm-disasm
   Build-depends:       array                 >= 0.3,
                        base,

--- a/llvm-pretty-bc-parser.cabal
+++ b/llvm-pretty-bc-parser.cabal
@@ -56,6 +56,9 @@ Library
                        Data.LLVM.BitCode.Record
 
   Ghc-options:         -Wall
+                       -Wunbanged-strict-patterns
+                       -O2
+                       -funbox-strict-fields
 
   Build-depends:       array       >= 0.3,
                        base        >= 4.8 && < 5,
@@ -72,7 +75,7 @@ Library
 Executable llvm-disasm
   Main-is:             LLVMDis.hs
   Default-language:    Haskell2010
-  Ghc-options:         -Wall
+  Ghc-options:         -Wall -Wunbanged-strict-patterns -O2
   Hs-source-dirs:      llvm-disasm
   Build-depends:       array                 >= 0.3,
                        base,

--- a/src/Data/LLVM/BitCode/BitString.hs
+++ b/src/Data/LLVM/BitCode/BitString.hs
@@ -74,13 +74,13 @@ data BitString = BitString
     -- unlimited size value.  However, this adds some overhead to various
     -- computations, and since LLVM Bitcode is unlikely to ever represent values
     -- greater than the native size (64 bits) as discrete values.  By changing
-    -- this to @Int@, the use of uboxed calculations is enabled for better
+    -- this to @Int@, the use of unboxed calculations is enabled for better
     -- performance.
     --
     -- The use of Int is potentially unsound because GHC only guarantees it's a
-    -- signed 32-bit integer.  However current implementation in all environments
-    -- where it's reasonable to use this parser have a 64-bit Int
-    -- implementatinon.  This can be verified via:
+    -- signed integer of at least 32-bits.  However current implementations in
+    -- all environments where it's reasonable to use this parser have a 64-bit
+    -- Int implementation.  This can be verified via:
     --
     --  > import Data.Bits
     --  > bitSizeMaybe (maxBound :: Int) >= Just 64
@@ -138,8 +138,8 @@ fromBitString (BitString l i) =
            , "could not be parsed into type with only", show n, "bits"
            ])
  where
- x    = fromInteger ival  -- use Num's conversion
- ival = toInteger i
+ x    = fromInteger ival  -- use Num to convert the Integer to the target type
+ ival = toInteger i  -- convert input to an Integer for ^^
 
 
 showBitString :: BitString -> ShowS

--- a/src/Data/LLVM/BitCode/BitString.hs
+++ b/src/Data/LLVM/BitCode/BitString.hs
@@ -73,8 +73,9 @@ data BitString = BitString
     -- Note: the bsData was originally an Integer, which allows an essentially
     -- unlimited size value.  However, this adds some overhead to various
     -- computations, and since LLVM Bitcode is unlikely to ever represent values
-    -- > native size (64 bits) as discrete values.  By changing this to @Int@,
-    -- the use of uboxed calculations is enabled for better performance.
+    -- greater than the native size (64 bits) as discrete values.  By changing
+    -- this to @Int@, the use of uboxed calculations is enabled for better
+    -- performance.
     --
     -- The use of Int is potentially unsound because GHC only guarantees it's a
     -- signed 32-bit integer.  However current implementation in all environments

--- a/src/Data/LLVM/BitCode/GetBits.hs
+++ b/src/Data/LLVM/BitCode/GetBits.hs
@@ -183,7 +183,9 @@ extractFromByteString !bitLim# !sBit# !nbits# bs =
 #if MIN_VERSION_base(4,16,0)
                 word8ToInt !w8# = word2Int# (word8ToWord# w8#)
 #else
--- technically #if !MIN_VERSION_ghc_prim(0,8,0), for GHC 9.2, but that isn't a define
+                -- technically #if !MIN_VERSION_ghc_prim(0,8,0), for GHC 9.2, but
+                -- since ghc_prim isn't a direct dependency and is re-exported
+                -- from base, this define needs to reference the base version.
                 word8ToInt = word2Int#
 #endif
                 -- getB# gets a value from a byte starting at bit0 of the byte
@@ -227,6 +229,8 @@ extractFromByteString !bitLim# !sBit# !nbits# bs =
                                         getB# 2# `orI#` getB# 3# `orI#`
                                         getB# 4# `orI#` getB# 5# `orI#`
                                         getB# 6# `orI#` getB# 7#
+                                  -- This is the catch-all loop for other sizes
+                                  -- not addressed above.
                                   _ -> let join !(W8# w#) !(I# a#) =
                                              I# ((a# `uncheckedIShiftL#` 8#)
                                                  `orI#` (word8ToInt w#))
@@ -255,6 +259,8 @@ extractFromByteString !bitLim# !sBit# !nbits# bs =
                                        getSB# 2# `orI#` getSB# 3# `orI#`
                                        getSB# 4# `orI#` getSB# 5# `orI#`
                                        getSB# 6# `orI#` getSB# 7#
+                                 -- n.b. these are hand-unrolled cases for common
+                                 -- sizes this is called for.
                                  9# -> getSB# 0# `orI#` getSB# 1# `orI#`
                                        getSB# 2# `orI#` getSB# 3# `orI#`
                                        getSB# 4# `orI#` getSB# 5# `orI#`
@@ -269,6 +275,8 @@ extractFromByteString !bitLim# !sBit# !nbits# bs =
                                         getSB# 12# `orI#` getSB# 13# `orI#`
                                         getSB# 14# `orI#` getSB# 15# `orI#`
                                         getSB# 16# `orI#` getSB# 17#
+                                 -- This is the catch-all loop for other sizes
+                                 -- not addressed above.
                                  _ -> let join !(W8# w#) !(I# a#) =
                                             I# ((a# `uncheckedIShiftL#` 8#)
                                                 `orI#` (word8ToInt w#))

--- a/src/Data/LLVM/BitCode/GetBits.hs
+++ b/src/Data/LLVM/BitCode/GetBits.hs
@@ -140,10 +140,10 @@ extractFromByteString bitLimit startBit numBits bs =
       ws = BS.take rcnt $ BS.drop s8 bs
 
       -- Combine the extracted bytes into an Integer value in wi.
-      wi = BS.foldr (\w a -> a `shiftL` 8 .|. fromIntegral w) (0::Integer) ws
+      wi = BS.foldr (\w a -> a `shiftL` 8 .|. fromIntegral w) (0::Int) ws
 
       -- Mask is 0-bit based set of bits wanted in the result
-      mask = ((1::Integer) `shiftL` bitCount numBits) - 1
+      mask = ((1::Int) `shiftL` bitCount numBits) - 1
 
       -- Shift the desired value down to byte alignment and then discard any
       -- excess high bits.

--- a/src/Data/LLVM/BitCode/GetBits.hs
+++ b/src/Data/LLVM/BitCode/GetBits.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE MagicHash #-}
 
 module Data.LLVM.BitCode.GetBits (
     GetBits
@@ -15,9 +17,11 @@ import           Data.LLVM.BitCode.BitString
 
 import           Control.Applicative ( Alternative(..) )
 import           Control.Monad ( MonadPlus(..) )
-import           Data.Bits ( (.&.), (.|.), shiftL, shiftR )
+import           Data.Bits ( (.&.) )
 import           Data.ByteString ( ByteString )
 import qualified Data.ByteString as BS
+import           GHC.Exts
+import           GHC.Word
 
 #if !MIN_VERSION_base(4,13,0)
 import           Control.Monad.Fail ( MonadFail )
@@ -125,36 +129,154 @@ instance MonadPlus GetBits where
 -- extract is not valid... i.e. > bitLimit).  Returns the Integer value along
 -- with the bit position following the extraction.
 
+-- There are two implementations: one builds an integer value by shifting bits,
+-- then shifts and masks the result to get the final value.  The other uses
+-- unlifted values and avoids the final shift by being smarter about individual
+-- compositions.  Their functionality should be identical, but it may be easier
+-- to debug the first.
+
+-- extractFromByteString bitLimit startBit numBits bs =
+--   let Bytes' s8 = fst (bitsToBytes startBit)
+--       Bytes' r8 = fst (bitsToBytes numBits)
+--       rcnt = r8 + 2 -- 2 == pre-shift overflow byte on either side
+
+--       -- Extract the relevant bits from the ByteCode, with padding to byte
+--       -- boundaries into ws.
+--       ws = BS.take rcnt $ BS.drop s8 bs
+
+--       -- Combine the extracted bytes into an Integer value in wi.
+--       wi = BS.foldr (\w a -> a `shiftL` 8 .|. fromIntegral w) (0::Int) ws
+
+--       -- Mask is 0-bit based set of bits wanted in the result
+--       mask = ((1::Int) `shiftL` bitCount numBits) - 1
+
+--       -- Shift the desired value down to byte alignment and then discard any
+--       -- excess high bits.
+--       vi = wi `shiftR` (bitCount startBit .&. 7) .&. mask
+
+--       updPos = addBitCounts startBit numBits
+--   in if updPos > bitLimit
+--      then Left ("Attempt to read bits past limit (newPos="
+--                 <> show updPos <> ", limit=" <> show bitLimit <> ")"
+--                )
+--      else Right (vi, updPos)
+
 extractFromByteString :: NumBits {-^ the last bit accessible in the ByteString -}
                       -> NumBits {-^ the bit to start extraction at -}
                       -> NumBits {-^ the number of bits to extract -}
                       -> ByteString {-^ the ByteString to extract from -}
-                      -> Either String (Integer, NumBits)
-extractFromByteString bitLimit startBit numBits bs =
-  let Bytes' s8 = fst (bitsToBytes startBit)
-      Bytes' r8 = fst (bitsToBytes numBits)
-      rcnt = r8 + 2 -- 2 == pre-shift overflow byte on either side
-
-      -- Extract the relevant bits from the ByteCode, with padding to byte
-      -- boundaries into ws.
-      ws = BS.take rcnt $ BS.drop s8 bs
-
-      -- Combine the extracted bytes into an Integer value in wi.
-      wi = BS.foldr (\w a -> a `shiftL` 8 .|. fromIntegral w) (0::Int) ws
-
-      -- Mask is 0-bit based set of bits wanted in the result
-      mask = ((1::Int) `shiftL` bitCount numBits) - 1
-
-      -- Shift the desired value down to byte alignment and then discard any
-      -- excess high bits.
-      vi = wi `shiftR` (bitCount startBit .&. 7) .&. mask
-
-      updPos = addBitCounts startBit numBits
-  in if updPos > bitLimit
-     then Left ("Attempt to read bits past limit (newPos="
-                <> show updPos <> ", limit=" <> show bitLimit <> ")"
-               )
-     else Right (vi, updPos)
+extractFromByteString :: NumBits -> NumBits -> NumBits -> ByteString
+                      -> Either String (Int, NumBits)
+extractFromByteString !bitLimit !startBit !numBits bs =
+  let !nbits# = bitCount# numBits
+  in if isTrue# ((1# `uncheckedIShiftL#` (nbits#)) /=# 0#)
+        -- (nbits# -# 1#) above would allow 64-bit value extraction, but this
+        -- function cannot actually support a size of 64, because Int# is signed,
+        -- so it doesn't properly use the high bit in numeric operations.  This
+        -- seems to be OK at this point because LLVM bitcode does not attempt to
+        -- encode actual 64-bit values.
+     then
+       let !sBit# = bitCount# startBit
+           !updPos# = sBit# +# nbits#
+           !bitLim# = bitCount# bitLimit
+       in if isTrue# (updPos# <=# bitLim#)
+          then
+            let !s8# = sBit# `uncheckedIShiftRL#` 3#
+                !hop# = sBit# `andI#` 7#
+                !r8# = ((hop# +# nbits# +# 7#) `uncheckedIShiftRL#` 3#)
+                !mask# = (1# `uncheckedIShiftL#` nbits#) -# 1#
+                getB# !i# =
+                  case i# of
+                    0# -> let !(W8# w#) = bs `BS.index` (I# s8#)
+                          in word2Int# w#
+                    _ -> let !(W8# w#) = (bs `BS.index` (I# (s8# +# i#)))
+                         in (word2Int# w#) `uncheckedIShiftL#` (8# *# i#)
+                getSB# !i# =
+                  case i# of
+                    0# -> let !(W8# w#) = bs `BS.index` (I# s8#)
+                          in (word2Int# w#) `uncheckedIShiftRL#` hop#
+                    _  -> let !(W8# w#) = bs `BS.index` (I# (s8# +# i#))
+                              !shft# = (8# *# i#) -# hop#
+                          in (word2Int# w#) `uncheckedIShiftL#` shft#
+                !vi# = mask# `andI#`
+                       (case hop# of
+                          0# -> case r8# of
+                                  1# -> getB# 0#
+                                  2# -> getB# 0# `orI#` getB# 1#
+                                  3# -> getB# 0# `orI#` getB# 1# `orI#`
+                                        getB# 2#
+                                  4# -> getB# 0# `orI#` getB# 1# `orI#`
+                                        getB# 2# `orI#` getB# 3#
+                                  5# -> getB# 0# `orI#` getB# 1# `orI#`
+                                        getB# 2# `orI#` getB# 3# `orI#`
+                                        getB# 4#
+                                  6# -> getB# 0# `orI#` getB# 1# `orI#`
+                                        getB# 2# `orI#` getB# 3# `orI#`
+                                        getB# 4# `orI#` getB# 5#
+                                  7# -> getB# 0# `orI#` getB# 1# `orI#`
+                                        getB# 2# `orI#` getB# 3# `orI#`
+                                        getB# 4# `orI#` getB# 5# `orI#`
+                                        getB# 6#
+                                  8# -> getB# 0# `orI#` getB# 1# `orI#`
+                                        getB# 2# `orI#` getB# 3# `orI#`
+                                        getB# 4# `orI#` getB# 5# `orI#`
+                                        getB# 6# `orI#` getB# 7#
+                                  _ -> let join !(W8# w#) !(I# a#) =
+                                             I# ((a# `uncheckedIShiftL#` 8#)
+                                                 `orI#` (word2Int# w#))
+                                           bs' = BS.take (I# (r8# +# 2#))
+                                                 $ BS.drop (I# s8#) bs
+                                           !(I# v#) = BS.foldr join (0::Int) bs'
+                                       in mask# `andI#` (v# `uncheckedIShiftRL#` hop#)
+                          _ -> case r8# of
+                                 1# -> getSB# 0#
+                                 2# -> getSB# 0# `orI#` getSB# 1#
+                                 3# -> getSB# 0# `orI#` getSB# 1# `orI#`
+                                       getSB# 2#
+                                 4# -> getSB# 0# `orI#` getSB# 1# `orI#`
+                                       getSB# 2# `orI#` getSB# 3#
+                                 5# -> getSB# 0# `orI#` getSB# 1# `orI#`
+                                       getSB# 2# `orI#` getSB# 3# `orI#`
+                                       getSB# 4#
+                                 6# -> getSB# 0# `orI#` getSB# 1# `orI#`
+                                       getSB# 2# `orI#` getSB# 3# `orI#`
+                                       getSB# 4# `orI#` getSB# 5#
+                                 7# -> getSB# 0# `orI#` getSB# 1# `orI#`
+                                       getSB# 2# `orI#` getSB# 3# `orI#`
+                                       getSB# 4# `orI#` getSB# 5# `orI#`
+                                       getSB# 6#
+                                 8# -> getSB# 0# `orI#` getSB# 1# `orI#`
+                                       getSB# 2# `orI#` getSB# 3# `orI#`
+                                       getSB# 4# `orI#` getSB# 5# `orI#`
+                                       getSB# 6# `orI#` getSB# 7#
+                                 9# -> getSB# 0# `orI#` getSB# 1# `orI#`
+                                       getSB# 2# `orI#` getSB# 3# `orI#`
+                                       getSB# 4# `orI#` getSB# 5# `orI#`
+                                       getSB# 6# `orI#` getSB# 7# `orI#`
+                                       getSB# 8#
+                                 18# -> getSB# 0# `orI#` getSB# 1# `orI#`
+                                        getSB# 2# `orI#` getSB# 3# `orI#`
+                                        getSB# 4# `orI#` getSB# 5# `orI#`
+                                        getSB# 6# `orI#` getSB# 7# `orI#`
+                                        getSB# 8# `orI#` getSB# 9# `orI#`
+                                        getSB# 10# `orI#` getSB# 11# `orI#`
+                                        getSB# 12# `orI#` getSB# 13# `orI#`
+                                        getSB# 14# `orI#` getSB# 15# `orI#`
+                                        getSB# 16# `orI#` getSB# 17#
+                                 _ -> let join !(W8# w#) !(I# a#) =
+                                            I# ((a# `uncheckedIShiftL#` 8#)
+                                                `orI#` (word2Int# w#))
+                                          bs' = BS.take (I# (r8# +# 2#))
+                                                $ BS.drop (I# s8#) bs
+                                          !(I# v#) = BS.foldr join (0::Int) bs'
+                                      in mask# `andI#` (v# `uncheckedIShiftRL#` hop#)
+                       )
+            in Right ((I# vi#), Bits' (I# updPos#))
+          else Left "Attempt to read bits past limit"
+     else
+       -- BitString stores an Int, but number of extracted bits is larger than
+       -- an Int can represent.
+       Left "Attempt to extracted large value"
 
 
 -- Basic Interface -------------------------------------------------------------


### PR DESCRIPTION
Boxed types are normally convenient, but for high speed processing of items of known sizes, unboxed types consume less memory and can be much quicker to work with.  This PR also removes the duplication in using the input `ByteString` argument at both the outer and inner "layers" of the `GetBits` monad (that was noticed in the previous PR).

Note: a follow-on PR will shift the use of `Int#` in this PR to `Word#` to resolve the signed/unsigned issue.
