### PR TITLE
Add quick flag and use unsigned unlifted Word#

### DIFF
--- a/llvm-pretty-bc-parser.cabal
+++ b/llvm-pretty-bc-parser.cabal
@@ -24,6 +24,10 @@ Flag regressions
   Description:         Enable regression testing build
   Default:             False
 
+Flag quick
+  Description:         Disable traces and validation of LLVM input; minimal parsing checking
+  Default:             False
+
 Source-repository head
   type:                git
   location:            http://github.com/galoisinc/llvm-pretty-bc-parser
@@ -59,6 +63,9 @@ Library
                        -Wunbanged-strict-patterns
                        -O2
                        -funbox-strict-fields
+
+  if flag(quick)
+    CPP-Options:       -DQUICK
 
   Build-depends:       array       >= 0.3,
                        base        >= 4.8 && < 5,

--- a/src/Data/LLVM/BitCode/BitString.hs
+++ b/src/Data/LLVM/BitCode/BitString.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE PatternSynonyms #-}
 
@@ -20,9 +21,14 @@ module Data.LLVM.BitCode.BitString
   )
 where
 
+#ifdef QUICK
+import Data.Bits ( Bits )
+import Numeric ( showIntAtBase )
+#else
 import Data.Bits ( bit, bitSizeMaybe, Bits )
-import GHC.Exts
 import Numeric ( showIntAtBase, showHex )
+#endif
+import GHC.Exts
 
 import Prelude hiding (take,drop,splitAt)
 
@@ -125,6 +131,9 @@ bitStringValue = bsData
 -- fromInteger to perform the target type conversion).
 
 fromBitString :: (Num a, Bits a) => BitString -> a
+#ifdef QUICK
+fromBitString (BitString _ i) = x
+#else
 fromBitString (BitString l i) =
   case bitSizeMaybe x of
     Nothing -> x
@@ -137,6 +146,7 @@ fromBitString (BitString l i) =
            , "(mask=0x" <> showHex i ")"
            , "could not be parsed into type with only", show n, "bits"
            ])
+#endif
  where
  x    = fromInteger ival  -- use Num to convert the Integer to the target type
  ival = toInteger i  -- convert input to an Integer for ^^

--- a/src/Data/LLVM/BitCode/Bitstream.hs
+++ b/src/Data/LLVM/BitCode/Bitstream.hs
@@ -26,8 +26,9 @@ import qualified Data.ByteString.Lazy as L
 import           Data.LLVM.BitCode.BitString as BS
 import           Data.LLVM.BitCode.GetBits
 import qualified Data.Map as Map
-import           Data.Word ( Word8, Word16, Word32 )
+#ifdef QUICK
 import           GHC.Exts
+#endif
 import           GHC.Word
 
 
@@ -61,6 +62,7 @@ vbr n = loop emptyBitString
        then loop acc'
        else return acc'
 
+#ifdef QUICK
 vbrInt :: NumBits -> GetBits Int
 vbrInt n@(Bits' (I# n#)) =
   let !cmask# = 1# `uncheckedIShiftL#` (n# -# 1#)
@@ -73,6 +75,7 @@ vbrInt n@(Bits' (I# n#)) =
                           let nxtshft# = nxt# `uncheckedIShiftL#` (n# -# 1#)
                           return (I# ((ic# `xorI#` cmask#)`orI#` nxtshft#))
   in loop
+#endif
 
 
 -- | Process a variable-bit encoded integer.

--- a/src/Data/LLVM/BitCode/GetBits.hs
+++ b/src/Data/LLVM/BitCode/GetBits.hs
@@ -6,7 +6,7 @@
 module Data.LLVM.BitCode.GetBits (
     GetBits
   , runGetBits
-  , fixed, align32bits
+  , fixed, fixedInt, align32bits
   , bytestring
   , label
   , isolate
@@ -334,6 +334,16 @@ fixed !(Bits' (I# n#)) = GetBits
             in (# pure $ toBitString (Bits' (I# n#)) (I# v#)
                , (# p#, lim# #)
                #)
+          Left e -> (# Left e, s #)
+
+fixedInt :: NumBits -> GetBits Int
+fixedInt !(Bits' (I# n#)) = GetBits
+  $ \ !s@(# cur#, lim# #) ->
+      \inp ->
+        case extractFromByteString lim# cur# n# inp of
+          Right getRes ->
+            let !(# v#, p# #) = getRes ()
+            in (# pure (I# v#) , (# p#, lim# #) #)
           Left e -> (# Left e, s #)
 
 

--- a/src/Data/LLVM/BitCode/IR.hs
+++ b/src/Data/LLVM/BitCode/IR.hs
@@ -5,7 +5,6 @@
 module Data.LLVM.BitCode.IR where
 
 import Data.LLVM.BitCode.Bitstream
-import Data.LLVM.BitCode.BitString
 import Data.LLVM.BitCode.IR.Blocks
 import Data.LLVM.BitCode.IR.Module (parseModuleBlock)
 import Data.LLVM.BitCode.Match
@@ -21,9 +20,7 @@ import Data.Word (Word16)
 
 -- | The magic number that identifies a @Bitstream@ structure as LLVM IR.
 llvmIrMagic :: Word16
-llvmIrMagic  = fromBitString (toBitString (Bits' 8) 0xc0
-                              `joinBitString`
-                              toBitString (Bits' 8) 0xde)
+llvmIrMagic = 0xdec0
 
 -- | Parse an LLVM Module out of a Bitstream object.
 parseModule :: Bitstream -> Parse Module

--- a/src/Data/LLVM/BitCode/IR/Constants.hs
+++ b/src/Data/LLVM/BitCode/IR/Constants.hs
@@ -425,10 +425,14 @@ parseConstantEntry t (getTy,cs) (fromEntry -> Just r) =
         _asmDialect    = mask `shiftR` 2
 
     asmStrSize <- field 1 numeric
+#ifndef QUICK
     Assert.recordSizeGreater r (1 + asmStrSize)
+#endif
 
     constStrSize <- field (2 + asmStrSize) numeric
+#ifndef QUICK
     Assert.recordSizeGreater r (2 + asmStrSize + constStrSize)
+#endif
 
     asmStr   <- fmap UTF8.decode $ parseSlice r  2               asmStrSize   char
     constStr <- fmap UTF8.decode $ parseSlice r (3 + asmStrSize) constStrSize char

--- a/src/Data/LLVM/BitCode/Parse.hs
+++ b/src/Data/LLVM/BitCode/Parse.hs
@@ -540,8 +540,12 @@ getTypeSymtab  = Parse (symTypeSymtab . envSymtab <$> ask)
 
 -- | Label a sub-computation with its context.
 label :: String -> Parse a -> Parse a
+#ifdef QUICK
+label _ m = m
+#else
 label l m = Parse $ do
   local (addLabel l) (unParse m)
+#endif
 
 -- | Fail, taking into account the current context.
 failWithContext :: String -> Parse a


### PR DESCRIPTION
This makes further performance modifications to use unsigned `Word#` instead of signed `Int#` and adds a `quick` flag (disabled by default).  When the `quick` flag is enabled, much of the error detection, verification, and other internal checks are removed; this mode is a further incremental performance gain but it should only be used in situations where well-formed bitcode from known-supported versions of LLVM willl be used.