### PR TITLE
Support three GHC versions at a time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,8 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.1"]
+        # See doc/developing.md
+        ghc: ["8.10.7", "9.0.2", "9.2.4"]
     name: build - ${{ matrix.ghc }} - ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/llvm-quick-fuzz.yml
+++ b/.github/workflows/llvm-quick-fuzz.yml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
+        # See doc/developing.md
         ghc: ["8.10.7"]
         llvm: [ "https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.0/clang+llvm-12.0.0-x86_64-apple-darwin.tar.xz"
               , "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/clang+llvm-11.0.0-x86_64-apple-darwin.tar.xz"

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ issue](https://github.com/GaloisInc/llvm-pretty-bc-parser/issues).
 
 Developers' documentation: [doc/developing.md](./doc/developing.md)
 
+## GHC Support
+
+llvm-pretty-bc-parser endeavors to support three versions of GHC at a time. See
+the developers' documentation for more details and a rationale:
+[doc/developing.md](./doc/developing.md).
+
 [fuzz-workflow]: https://github.com/GaloisInc/llvm-pretty-bc-parser/blob/master/.github/workflows/llvm-quick-fuzz.yml
 [llvm13]: https://github.com/GaloisInc/llvm-pretty-bc-parser/issues?q=is%3Aopen+is%3Aissue+label%3Allvm%2F13.0
 [llvm14]: https://github.com/GaloisInc/llvm-pretty-bc-parser/issues?q=is%3Aopen+is%3Aissue+label%3Allvm%2F14.0

--- a/README.md
+++ b/README.md
@@ -55,7 +55,11 @@ Developers' documentation: [doc/developing.md](./doc/developing.md)
 
 llvm-pretty-bc-parser endeavors to support three versions of GHC at a time. See
 the developers' documentation for more details and a rationale:
-[doc/developing.md](./doc/developing.md).
+[doc/developing.md](./doc/developing.md). Currently supported:
+
+- GHC 8.10.7
+- GHC 9.0.2
+- GHC 9.2.4
 
 [fuzz-workflow]: https://github.com/GaloisInc/llvm-pretty-bc-parser/blob/master/.github/workflows/llvm-quick-fuzz.yml
 [llvm13]: https://github.com/GaloisInc/llvm-pretty-bc-parser/issues?q=is%3Aopen+is%3Aissue+label%3Allvm%2F13.0

--- a/doc/developing.md
+++ b/doc/developing.md
@@ -83,3 +83,17 @@ See [the README in that directory](../fuzzing/README.md).
 ### `unit-test`
 
 These are run with `cabal test` or `cabal new-test`.
+
+## Supported GHC Versions
+
+A policy on which GHC versions to support must balance the benefits of wide
+applicability/support against the drawbacks of additional costs of development,
+including developer time and CI budgets. Our policy is to support three versions
+of GHC at a time. We try to support new versions of GHC as soon as they are
+supported by all of libraries that llvm-pretty-bc-parser depends on.
+
+When updating the supported GHC versions, remember to update:
+
+- [The README](../README.md)
+- [The Cabal file](../llvm-pretty-bc-parser.cabal)'s `Tested-with` field
+- [CI workflows](../.github/workflows)

--- a/llvm-pretty-bc-parser.cabal
+++ b/llvm-pretty-bc-parser.cabal
@@ -8,7 +8,7 @@ Category:            Text
 Build-type:          Simple
 Cabal-version:       >=1.10
 Synopsis:            LLVM bitcode parsing library
-Tested-with:         GHC==8.0.2, GHC==8.2.2, GHC==8.4.3, GHC==8.6.1
+Tested-with:         GHC==8.10.7, GHC==9.0.2, GHC==9.2.4
 
 Description:
   A parser for the LLVM bitcode file format, yielding a Module from the


### PR DESCRIPTION
I'm not tied to this particular policy, I just saw that we were running against five GHC versions in CI and it seemed like a bit much.

Looks like this will require a change to the repository settings to not require the GHC versions that are dropped in this PR.