### PR TITLE
Support LLVM 13

### DIFF
--- a/.github/workflows/llvm-quick-fuzz.yml
+++ b/.github/workflows/llvm-quick-fuzz.yml
@@ -23,7 +23,8 @@ jobs:
         os: [ubuntu-22.04]
         # See doc/developing.md
         ghc: ["8.10.7"]
-        llvm: [ "https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.0/clang+llvm-12.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz"
+        llvm: [ "https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.0/clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz"
+              , "https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.0/clang+llvm-12.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz"
               , "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/clang+llvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz"
               , "https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz"
               , "https://releases.llvm.org/9.0.0/clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ compilers.
 |           | v10.0   | ✓                             |              |                      |
 |           | v11.0   | ✓                             |              |                      |
 |           | v12.0   | ✓                             |              |                      |
-|           | v13.0   |                               |              | See [issues][llvm13] |
+|           | v13.0   | ✓                             |              | See [issues][llvm13] |
 |           | v14.0   |                               |              | See [issues][llvm14] |
 | `clang++` | v3.4    |                               |              |                      |
 |           | v3.5    |                               |              |                      |

--- a/disasm-test/Main.hs
+++ b/disasm-test/Main.hs
@@ -205,7 +205,10 @@ cube = TS.mkCUBE
   { TS.inputDirs = ["disasm-test/tests"]
   , TS.rootName = "*.ll"
   , TS.separators = "."
-  , TS.validParams = [ ("llvm-range", Just ["pre-llvm11", "at-least-llvm12"])
+  , TS.validParams = [ ("llvm-range", Just [ "pre-llvm11"
+                                           , "at-least-llvm12"
+                                           , "at-least-llvm13"
+                                           ])
                      ]
     -- Somewhat unusually for tasty-sugar, we make the expectedSuffix the same
     -- as the rootName suffix. This is because we are comparing the contents of

--- a/disasm-test/Main.hs
+++ b/disasm-test/Main.hs
@@ -307,7 +307,11 @@ runTest llvmVer sweet expct
                    ]
           in case lookup "llvm-range" (TS.expParamsMatch expct) of
                Just (TS.Explicit v) -> specMatchesInstalled v
-               Just (TS.Assumed  v) -> specMatchesInstalled v
+               Just (TS.Assumed v)
+                 |  v == "pre-llvm11" || v == "at-least-llvm12"
+                 -> specMatchesInstalled v
+                 |  otherwise
+                 -> False
                _ -> error "llvm-range unknown"
 
 -- | Assemble some llvm assembly, producing a bitcode file in /tmp.

--- a/disasm-test/tests/di-arg-list.at-least-llvm13.ll
+++ b/disasm-test/tests/di-arg-list.at-least-llvm13.ll
@@ -1,0 +1,43 @@
+; ModuleID = 'di-arg-list.c'
+source_filename = "di-arg-list.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind readnone uwtable willreturn
+define dso_local i32 @f(i32 %0, i32 %1) local_unnamed_addr #0 !dbg !9 {
+  call void @llvm.dbg.value(metadata i32 %0, metadata !14, metadata !DIExpression()), !dbg !17
+  call void @llvm.dbg.value(metadata i32 %1, metadata !15, metadata !DIExpression()), !dbg !17
+  call void @llvm.dbg.value(metadata !DIArgList(i32 %0, i32 %1), metadata !16, metadata !DIExpression(DW_OP_LLVM_arg, 0, DW_OP_LLVM_arg, 1, DW_OP_plus, DW_OP_stack_value)), !dbg !17
+  ret i32 0, !dbg !18
+}
+
+; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
+declare void @llvm.dbg.value(metadata, metadata, metadata) #1
+
+attributes #0 = { mustprogress nofree norecurse nosync nounwind readnone uwtable willreturn "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { nofree nosync nounwind readnone speculatable willreturn }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5, !6}
+!llvm.ident = !{!7}
+!llvm.commandline = !{!8}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 13.0.1", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "di-arg-list.c", directory: "/home/rscott/Documents/Hacking/Haskell/llvm-pretty-bc-parser/disasm-test/tests")
+!2 = !{}
+!3 = !{i32 7, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{i32 7, !"uwtable", i32 1}
+!7 = !{!"clang version 13.0.1"}
+!8 = !{!"/home/rscott/Software/clang+llvm-13.0.1/bin/clang-13 -S -emit-llvm -g -O1 -frecord-command-line di-arg-list.c -o di-arg-list.at-least-llvm13.ll"}
+!9 = distinct !DISubprogram(name: "f", scope: !1, file: !1, line: 1, type: !10, scopeLine: 1, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !13)
+!10 = !DISubroutineType(types: !11)
+!11 = !{!12, !12, !12}
+!12 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!13 = !{!14, !15, !16}
+!14 = !DILocalVariable(name: "x", arg: 1, scope: !9, file: !1, line: 1, type: !12)
+!15 = !DILocalVariable(name: "y", arg: 2, scope: !9, file: !1, line: 1, type: !12)
+!16 = !DILocalVariable(name: "z", scope: !9, file: !1, line: 2, type: !12)
+!17 = !DILocation(line: 0, scope: !9)
+!18 = !DILocation(line: 3, column: 3, scope: !9)

--- a/disasm-test/tests/di-arg-list.c
+++ b/disasm-test/tests/di-arg-list.c
@@ -1,0 +1,4 @@
+int f(int x, int y) {
+  int z = x + y;
+  return 0;
+}

--- a/src/Data/LLVM/BitCode/GetBits.hs
+++ b/src/Data/LLVM/BitCode/GetBits.hs
@@ -124,12 +124,12 @@ instance MonadPlus GetBits where
 -- compositions.  Their functionality should be identical, but it may be easier
 -- to debug the first.
 
-extractFromByteString' :: NumBits {-^ the last bit accessible in the ByteString -}
-                       -> NumBits {-^ the bit to start extraction at -}
-                       -> NumBits {-^ the number of bits to extract -}
-                       -> ByteString {-^ the ByteString to extract from -}
-                       -> Either String (Int, NumBits)
-extractFromByteString' bitLimit startBit numBits bs =
+_extractFromByteString' :: NumBits {-^ the last bit accessible in the ByteString -}
+                        -> NumBits {-^ the bit to start extraction at -}
+                        -> NumBits {-^ the number of bits to extract -}
+                        -> ByteString {-^ the ByteString to extract from -}
+                        -> Either String (Int, NumBits)
+_extractFromByteString' bitLimit startBit numBits bs =
   let Bytes' s8 = fst (bitsToBytes startBit)
       Bytes' r8 = fst (bitsToBytes numBits)
       rcnt = r8 + 2 -- 2 == pre-shift overflow byte on either side

--- a/src/Data/LLVM/BitCode/IR/Function.hs
+++ b/src/Data/LLVM/BitCode/IR/Function.hs
@@ -16,7 +16,6 @@ import           Data.LLVM.BitCode.IR.Attrs
 import           Data.LLVM.BitCode.Match
 import           Data.LLVM.BitCode.Parse
 import           Data.LLVM.BitCode.Record
-import           Data.LLVM.BitCode.Record
 
 import           Text.LLVM.AST
 import           Text.LLVM.Labels

--- a/src/Data/LLVM/BitCode/IR/Metadata.hs
+++ b/src/Data/LLVM/BitCode/IR/Metadata.hs
@@ -705,9 +705,9 @@ parseMetadataEntry vt mt pm (fromEntry -> Just r) =
 
       (diFlags0, spFlags0) <-
         if hasSPFlags then
-          (,) <$> parseField r (11 + 2) numeric <*> pure 0
-        else
           (,) <$> parseField r 11 numeric <*> parseField r 9 numeric
+        else
+          (,) <$> parseField r (11 + 2) numeric <*> pure 0
 
       let diFlagMainSubprogram = bit 21 :: Word32
           hasOldMainSubprogramFlag = (diFlags0 .&. diFlagMainSubprogram) /= 0

--- a/src/Data/LLVM/BitCode/IR/Metadata.hs
+++ b/src/Data/LLVM/BitCode/IR/Metadata.hs
@@ -680,8 +680,8 @@ parseMetadataEntry vt mt pm (fromEntry -> Just r) =
              then pure 0
              else parseField r 18 numeric) -- dicuNameTableKind
         <*> (if recordSize <= 19
-             then pure 0
-             else parseField r 19 numeric) -- dicuRangesBaseAddress
+             then pure False
+             else parseField r 19 nonzero) -- dicuRangesBaseAddress
         <*> (if recordSize <= 20
              then pure Nothing
              else mdStringOrNull ctx pm <$> parseField r 20 numeric) -- dicuSysRoot

--- a/unit-test/Tests/Instances.hs
+++ b/unit-test/Tests/Instances.hs
@@ -80,6 +80,7 @@ instance Arbitrary lab => Arbitrary (DISubprogram' lab)               where arbi
 instance Arbitrary DISubrange                                         where arbitrary = genericArbitrary uniform
 instance Arbitrary lab => Arbitrary (DISubroutineType' lab)           where arbitrary = genericArbitrary uniform
 instance Arbitrary lab => Arbitrary (DILabel' lab)                    where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DIArgList' lab)                  where arbitrary = genericArbitrary uniform
 
 -- Newtypes
 instance Arbitrary Ident  where arbitrary = genericArbitrary uniform


### PR DESCRIPTION
This contains two key fixes needed to support LLVM 13:

## Support `METADATA_ARG_LIST`

Fixes #174.

## Support newer inline `asm` codes

One code (`CST_CODE_INLINEASM_OLD3`) was introduced in LLVM 13, and another (`CST_CODE_INLINEASM`) was introduced in LLVM 14. For the most part, they are parsed identically to previous inline `asm` codes, but with some minor differences. I have consolidated the logic for parsing all inline `asm` codes into a single `parseInlineAsm` function.

Fixes #184.

-----

The rest of the commits are needed to make the test case for #174 work, which exercises quite a bit of pretty-printing functionality that was not previously tested. These include fixes for https://github.com/elliottt/llvm-pretty/issues/105, https://github.com/elliottt/llvm-pretty/issues/107, #211, and #212. This also requires bumping the `llvm-pretty` submodule to bring in the changes from https://github.com/elliottt/llvm-pretty/pull/108.