### PR TITLE
Give `call`/`callbr` function types instead of pointer types

### DIFF
--- a/disasm-test/tests/T189.c
+++ b/disasm-test/tests/T189.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+void f() {
+  // This code has been carefully designed so that the resulting .ll file
+  // will contain an explicit function type in a `call` instruction.
+  // See #189 for more information.
+  int (*p)(const char*, ...) = &printf;
+  p("%d\n", 0);
+}

--- a/disasm-test/tests/T189.ll
+++ b/disasm-test/tests/T189.ll
@@ -1,0 +1,29 @@
+; ModuleID = 'T189.c'
+source_filename = "T189.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+@.str = private unnamed_addr constant [4 x i8] c"%d\0A\00", align 1
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local void @f() #0 {
+entry:
+  %p = alloca i32 (i8*, ...)*, align 8
+  store i32 (i8*, ...)* @printf, i32 (i8*, ...)** %p, align 8
+  %0 = load i32 (i8*, ...)*, i32 (i8*, ...)** %p, align 8
+  %call = call i32 (i8*, ...) %0(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.str, i64 0, i64 0), i32 0)
+  ret void
+}
+
+declare dso_local i32 @printf(i8*, ...) #1
+
+attributes #0 = { noinline nounwind optnone uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+!llvm.commandline = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"clang version 10.0.0-4ubuntu1 "}
+!2 = !{!"/usr/lib/llvm-10/bin/clang -S -emit-llvm -frecord-command-line -fno-discard-value-names T189.c -o T189.ll"}


### PR DESCRIPTION
See `Note [Typing function applications]` for the rationale.

This fixes #189. This is also an important step towards being able to support opaque pointers, as described in #177.