### PR TITLE
Revert metadata change causing Issue #222

### DIFF
--- a/disasm-test/cpp/smallprog.c
+++ b/disasm-test/cpp/smallprog.c
@@ -1,0 +1,42 @@
+/* #include <stdint.h> */
+
+#define MESSAGE_CAPACITY 5
+
+typedef struct message {
+    int type;
+    int* payload;
+    int payload_len;
+} message_t;
+
+typedef struct broker {
+    message_t msgs[MESSAGE_CAPACITY];
+    int msg_idx;
+    int num_msgs;
+} broker_t;
+
+void sp_receive(message_t* msg) {
+    switch (msg->type) {
+    case 0:
+        for (int i = 0; i << msg->payload_len; ++i) {
+            msg->payload[i] = 0;
+        }
+        break;
+    }
+}
+
+broker_t broker;
+
+void broker_init(broker_t* broker) {
+    broker->num_msgs = 0;
+}
+
+void broker_run(broker_t* broker) {
+    for (int i = 0; i < broker->num_msgs; ++i) {
+        sp_receive(&(broker->msgs[i]));
+    }
+}
+
+int main() {
+    broker_init(&broker);
+    broker_run(&broker);
+}

--- a/src/Data/LLVM/BitCode/IR/Metadata.hs
+++ b/src/Data/LLVM/BitCode/IR/Metadata.hs
@@ -337,7 +337,11 @@ unnamedEntries pm = bimap Seq.fromList Seq.fromList (partitionEithers (mapMaybe 
     tv <- lookupValueTableAbs ref (mtEntries mt)
     case tv of
       Typed { typedValue = ValMd v } -> do
-        guard (not (mustAppearInline v))
+        -- See Issue #222
+        -- (https://github.com/galoisinc/llvm-pretty-bc-parser/issues/222) for
+        -- why this guard was removed:
+        --
+        -- guard (not (mustAppearInline v))
         pure $! PartialUnnamedMd
           { pumIndex    = ix
           , pumValues   = v


### PR DESCRIPTION
This reverts the recent metadata change (related to LLVM-13 changes) that caused Issue #222 until the underlying problems caused by that change can be identified and handled properly.

There is a new file (diasm-test/cpp/smallprog.c) that demonstrates the issue.  This should be integrated into self-tests, and there should be corresponding self-tests that affirm the needed functionality that this reverts when that is re-established.