### PR TITLE
Support building with GHC 9.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         # See doc/developing.md
-        ghc: ["8.10.7", "9.0.2", "9.2.4"]
+        ghc: ["9.2.8", "9.4.5", "9.6.2"]
     name: build - ${{ matrix.ghc }} - ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/llvm-quick-fuzz.yml
+++ b/.github/workflows/llvm-quick-fuzz.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         # See doc/developing.md
-        ghc: ["8.10.7"]
+        ghc: ["9.2.8"]
         llvm: [ "https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0.2/clang+llvm-16.0.2-x86_64-linux-gnu-ubuntu-22.04.tar.xz"
               , "https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz"
               , "https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz"

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ llvm-pretty-bc-parser endeavors to support three versions of GHC at a time. See
 the developers' documentation for more details and a rationale:
 [doc/developing.md](./doc/developing.md). Currently supported:
 
-- GHC 8.10.7
-- GHC 9.0.2
-- GHC 9.2.4
+- GHC 9.2.8
+- GHC 9.4.5
+- GHC 9.6.2
 
 [fuzz-workflow]: https://github.com/GaloisInc/llvm-pretty-bc-parser/blob/master/.github/workflows/llvm-quick-fuzz.yml
 [llvm13]: https://github.com/GaloisInc/llvm-pretty-bc-parser/issues?q=is%3Aopen+is%3Aissue+label%3Allvm%2F13.0

--- a/llvm-pretty-bc-parser.cabal
+++ b/llvm-pretty-bc-parser.cabal
@@ -173,8 +173,6 @@ Executable fuzz-llvm-disasm
                        xml,
                        time,
                        deepseq,
-                       abstract-par,
-                       monad-par,
                        transformers,
                        llvm-pretty,
                        llvm-pretty-bc-parser

--- a/src/Data/LLVM/BitCode/Parse.hs
+++ b/src/Data/LLVM/BitCode/Parse.hs
@@ -13,13 +13,15 @@ import           Text.LLVM.AST
 import           Text.LLVM.PP
 
 import           Control.Applicative (Alternative(..))
+import           Control.Monad (MonadPlus(..), unless)
 #if !MIN_VERSION_base(4,13,0)
 import           Control.Monad.Fail (MonadFail)
 import qualified Control.Monad.Fail -- makes fail visible for instance
 #endif
-import           Control.Monad.Except
-import           Control.Monad.Reader
-import           Control.Monad.State.Strict
+import           Control.Monad.Fix (MonadFix)
+import           Control.Monad.Except (MonadError(..), Except, runExcept)
+import           Control.Monad.Reader (MonadReader(..), ReaderT(..))
+import           Control.Monad.State.Strict (MonadState(..), StateT(..))
 import           Data.Maybe (fromMaybe)
 import           Data.Semigroup
 import           Data.Typeable (Typeable)


### PR DESCRIPTION
This makes two changes to `llvm-pretty-bc-parser` to make it build with GHC 9.6:

* Because `mtl-2.3.*` no longer re-exports `Control.Monad` or `Control.Monad.Fix`, I needed to tighten up the imports in `Data.LLVM.BitCode.Parse` to make it build with GHC 9.6, which bundles `mtl-2.3.1`.
* Bump the `llvm-pretty` submodule to bring in the changes from https://github.com/elliottt/llvm-pretty/pull/112.

This also updates the `README` and CI to test against GHC 9.2, 9.4, and 9.6 (the three most recent GHC releases at the time of writing).

Fixes #224.