### PR TITLE
Llvm regressions

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -28,6 +28,7 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: cachix/install-nix-action@v20
         with:

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -9,6 +9,9 @@ on:
 
 jobs:
   build:
+    # This job builds the main package, via a number of GHC versions.  This is
+    # the build that would be used by downstream packages using this as a
+    # dependency; this does not build documentation or tests.
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -27,6 +30,7 @@ jobs:
         run: nix build -L github:${{ github.repository }}/${{ github.sha }}#llvm-pretty-bc-parser.${{ matrix.ghc-version }}
 
   tests:
+    # This job builds the tests, and then runs the tests (in two different steps)
     runs-on: ubuntu-latest
     steps:
       - uses: cachix/install-nix-action@v20
@@ -45,6 +49,7 @@ jobs:
         run: nix build -L github:${{ github.repository }}/${{ github.sha }}#TESTS
 
   doc:
+    # This job builds the documentation (e.g. Hackage, etc.)
     runs-on: ubuntu-latest
     steps:
       - uses: cachix/install-nix-action@v20

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -28,7 +28,6 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     steps:
       - uses: cachix/install-nix-action@v20
         with:

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc-version: [ "ghc96", "ghc94", "ghc92", "ghc810", "ghc88" ]
+        ghc-version: [ "ghc94", "ghc92", "ghc810", "ghc88" ]
     steps:
       - uses: cachix/install-nix-action@v20
         with:

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -30,7 +30,10 @@ jobs:
         run: nix build -L github:${{ github.repository }}/${{ github.sha }}#llvm-pretty-bc-parser.${{ matrix.ghc-version }}
 
   tests:
-    # This job builds the tests, and then runs the tests (in two different steps)
+    # This job builds the tests, and then runs the tests (in two different
+    # steps).  Note that for llvm-pretty-bc-parser, multiple LLVM versions will
+    # be tested; the actual list of versions is specified in the `flake.nix` file
+    # used (see the NOTE comment in that file).
     runs-on: ubuntu-latest
     steps:
       - uses: cachix/install-nix-action@v20

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -1,0 +1,60 @@
+name: llvm-pretty-bc-parser nix CI
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release-**'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ghc-version: [ "ghc96", "ghc94", "ghc92", "ghc810", "ghc88" ]
+    steps:
+      - uses: cachix/install-nix-action@v20
+        with:
+          nix_path: nixpkgs=channel:nixos-23.05
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: cachix/cachix-action@v12
+        with:
+          name: galois
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - name: build ${{ matrix.ghc-version }}
+        shell: bash
+        run: nix build github:${{ github.repository }}/${{ github.sha }}#llvm-pretty-bc-parser.${{ matrix.ghc-version }}
+
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cachix/install-nix-action@v20
+        with:
+          nix_path: nixpkgs=channel:nixos-23.05
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: cachix/cachix-action@v12
+        with:
+          name: galois
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - name: test build
+        shell: bash
+        run: nix build github:${{ github.repository }}/${{ github.sha }}#TESTS_PREP
+      - name: test
+        shell: bash
+        run: nix build -L github:${{ github.repository }}/${{ github.sha }}#TESTS
+
+  doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cachix/install-nix-action@v20
+        with:
+          nix_path: nixpkgs=channel:nixos-23.05
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: cachix/cachix-action@v12
+        with:
+          name: galois
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - name: doc
+        shell: bash
+        run: nix build github:${{ github.repository }}/${{ github.sha }}#DOC

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -24,7 +24,7 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: build ${{ matrix.ghc-version }}
         shell: bash
-        run: nix build github:${{ github.repository }}/${{ github.sha }}#llvm-pretty-bc-parser.${{ matrix.ghc-version }}
+        run: nix build -L github:${{ github.repository }}/${{ github.sha }}#llvm-pretty-bc-parser.${{ matrix.ghc-version }}
 
   tests:
     runs-on: ubuntu-latest

--- a/disasm-test/Main.hs
+++ b/disasm-test/Main.hs
@@ -141,8 +141,12 @@ getLLVMToolVersion toolName toolPath = do
   let isVerLine = isInfixOf "LLVM version"
       dropLetter = dropWhile (all isLetter)
       getVer (Right inp) =
-        -- example inp: "LLVM version 10.0.1"
-        head $ dropLetter $ words $ head $ filter isVerLine $ lines inp
+        -- example inp: "LLVM version 10.0.1" or "clang version 11.1.0"
+        case filter isVerLine $ lines inp of
+          [] -> "NO VERSION IDENTIFIED FOR " <> toolName
+          (l:_) -> case dropLetter $ words l of
+            [] -> toolName <> " VERSION NOT PARSED: " <> l
+            (v:_) -> v
       getVer (Left full) = full
   mkVC toolName . getVer <$> readProcessVersion toolPath
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,34 @@
 {
   "nodes": {
+    "fgl-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1676021714,
+        "narHash": "sha256-812R4Hf/smMikINWgpvDYOLm6h+PkF6FAsSPcHSzKBE=",
+        "owner": "haskell",
+        "repo": "fgl",
+        "rev": "b8c417f470dd6ac25eebacd326c3b2db85e71f27",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "5.8.1.1",
+        "repo": "fgl",
+        "type": "github"
+      }
+    },
+    "fgl-visualize-src": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-2EC57Y+B5ryWjWeLqzHeSNkb4RjUtvj8+8vebz86dnQ=",
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/fgl-visualize-0.1.0.1/fgl-visualize-0.1.0.1.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/fgl-visualize-0.1.0.1/fgl-visualize-0.1.0.1.tar.gz"
+      }
+    },
     "levers": {
       "inputs": {
         "nixpkgs": [
@@ -54,6 +83,8 @@
     },
     "root": {
       "inputs": {
+        "fgl-src": "fgl-src",
+        "fgl-visualize-src": "fgl-visualize-src",
         "levers": "levers",
         "llvm-pretty-src": "llvm-pretty-src",
         "nixpkgs": "nixpkgs"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,65 @@
+{
+  "nodes": {
+    "levers": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1687557470,
+        "narHash": "sha256-T0TAGZPiI5cwWR2OMLVYW7aj3Aco7v8qIVF7JoEgO9Y=",
+        "owner": "kquick",
+        "repo": "nix-levers",
+        "rev": "0e31d80978a9fb6a96df0722aa298d008a57c53e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kquick",
+        "repo": "nix-levers",
+        "type": "github"
+      }
+    },
+    "llvm-pretty-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687789214,
+        "narHash": "sha256-dqy1HMfrpz3t02xFRbGxPjc8uh5kC/edVI9aLPqlJ/o=",
+        "owner": "elliottt",
+        "repo": "llvm-pretty",
+        "rev": "94e384842b214ba72446d1694446fb5261ab6ce2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "elliottt",
+        "repo": "llvm-pretty",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1685566663,
+        "narHash": "sha256-btHN1czJ6rzteeCuE/PNrdssqYD2nIA4w48miQAFloM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4ecab3273592f27479a583fb6d975d4aba3486fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "levers": "levers",
+        "llvm-pretty-src": "llvm-pretty-src",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -103,6 +103,9 @@
             (builtins.map
               (llvm-pretty-bc-parser-test llvm-pretty-bc-parser-test-build)
               [
+                # NOTE: this is the main location which determines what LLVM
+                # versions are tested.  The default is to run each of the listed
+                # LLVM versions here in parallel.
                 pkgs.llvm_10
                 pkgs.llvm_11
               ]

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,137 @@
+{
+  # nix build .
+  # nix develop
+  # nix run .  [runs llvm-disasm]
+  #
+  # nix run github:galoisinc/llvm-pretty   [runs llvm-disasm]
+
+  description = "Flake to build the haskell-src package 'llvm-pretty-bc-parser' and dependencies";
+
+  nixConfig.bash-prompt-suffix = "llvm-pretty-bc-parser.env} ";
+
+  inputs = {
+    nixpkgs = { url = "github:nixos/nixpkgs/23.05"; };
+    levers = {
+      url = "github:kquick/nix-levers";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    llvm-pretty-src = {
+      url = "github:elliottt/llvm-pretty";
+      flake = false;
+    };
+  };
+
+  outputs = { self, levers, nixpkgs
+            , llvm-pretty-src
+            }:
+    let
+      shellWith = pkgs: adds: drv: drv.overrideAttrs(old:
+        { buildInputs = old.buildInputs ++ adds pkgs; });
+      # Add additional packages useful for a development shell, generally
+      # representing test packages or non-propagated build dependencies of
+      # various sub-packages.
+      shellPkgs = pkgs: [
+        # pkgs.haskell.compiler.integer-simple.ghc8107
+        # pkgs.haskell.packages.ghc8107.profiteur
+        pkgs.cabal-install
+        pkgs.llvm_11
+        pkgs.clang_11
+      ];
+    in rec {
+      devShells =
+        let oneshell = s: n:
+              let pkgs = import nixpkgs { system=s; };
+              in levers.variedTargets
+                { ghcver = levers.validGHCVersions pkgs.haskell.compiler; }
+                ( { ghcver, ... } @ vargs:
+                  shellWith pkgs shellPkgs
+                    (self.packages.${s}.${n}.${ghcver}.env.overrideAttrs (a:
+                      {
+                        # Set envvars here
+                      }
+                    )));
+        in levers.eachSystem
+          (s:
+            let pkgs = import nixpkgs { system=s; };
+                names = builtins.attrNames (self.packages.${s});
+                outs = builtins.removeAttrs
+                  (pkgs.lib.genAttrs names (oneshell s))
+                  [ "ghc" ];
+                shells = pkgs.lib.attrsets.mapAttrs (n: v: v.default) outs;
+            in shells
+          ) ;
+
+      packages = levers.eachSystem (system:
+        let
+          mkHaskell = levers.mkHaskellPkg {
+            inherit nixpkgs system;
+            };
+          pkgs = import nixpkgs { inherit system; };
+          wrap = levers.pkg_wrapper system pkgs;
+          haskellAdj = drv:
+            with (pkgs.haskell).lib;
+            dontHaddock (dontCheck (dontBenchmark (drv)));
+          llvm-pretty-bc-parser-test = built: llvm:
+            derivation {
+              inherit system;
+              name = "llvm-pretty-bc-parser-test-with-llvm${llvm.version}";
+              builder = "${pkgs.bash}/bin/bash";
+              args = [ "-c"
+                       ''
+                       ${pkgs.coreutils}/bin/cp -r ${built}/test-build/* .
+                       export PATH=${llvm}/bin:${pkgs.diffutils}/bin:$PATH
+                       ./dist/build/unit-test/unit-test
+                       ./dist/build/disasm-test/disasm-test
+                       echo OK > $out
+                       ''
+                     ];
+              buildInputs = [ llvm pkgs.diffutils pkgs.coreutils ];
+            };
+        in rec {
+          default = llvm-pretty-bc-parser;
+          TESTS = wrap "llvm-pretty-bc-parser-TESTS"
+            (builtins.map
+              (llvm-pretty-bc-parser-test llvm-pretty-bc-parser-test-build)
+              [
+                pkgs.llvm_10
+                pkgs.llvm_11
+              ]
+            );
+          DOC = wrap "llvm-pretty-bc-parser-DOC"
+            [ llvm-pretty-bc-parser-doc ];
+          llvm-pretty = mkHaskell "llvm-pretty" llvm-pretty-src {
+            adjustDrv = args: haskellAdj;
+          };
+          llvm-pretty-bc-parser = mkHaskell "llvm-pretty-bc-parser" self {
+            inherit llvm-pretty;
+            adjustDrv = args: haskellAdj;
+          };
+          llvm-pretty-bc-parser-test-build = mkHaskell "llvm-pretty-bc-parser-test-build" self {
+            inherit llvm-pretty;
+            adjustDrv = args: drv:
+              with pkgs.haskell.lib;
+              (doCheck (haskellAdj drv)).overrideAttrs (a:
+                { checkPhase = "echo skipping checks";
+                  postInstall = ''
+                    mkdir $out/test-build
+                    cp llvm-pretty-bc-parser.cabal $out/test-build
+                    mkdir $out/test-build/disasm-test
+                    cp -r disasm-test/tests $out/test-build/disasm-test
+                    cp -r dist $out/test-build/
+                    '';
+                });
+          };
+          llvm-pretty-bc-parser-tests = mkHaskell "llvm-pretty-bc-parser-tests" self {
+            inherit llvm-pretty;
+            adjustDrv = args: drv:
+              with pkgs.haskell.lib;
+              addExtraLibrary (dontHaddock drv) pkgs.llvm;
+          };
+          llvm-pretty-bc-parser-doc = mkHaskell "llvm-pretty-bc-parser-doc" self {
+            inherit llvm-pretty;
+            adjustDrv = args: drv:
+              pkgs.haskell.lib.dontCheck (pkgs.haskell.lib.dontBenchmark drv);
+          };
+        });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -19,10 +19,20 @@
       url = "github:elliottt/llvm-pretty";
       flake = false;
     };
+    fgl-src = {
+      url = "github:haskell/fgl/5.8.1.1";
+      flake = false;
+    };
+    fgl-visualize-src = {
+      url = "https://hackage.haskell.org/package/fgl-visualize-0.1.0.1/fgl-visualize-0.1.0.1.tar.gz";
+      flake = false;
+    };
   };
 
   outputs = { self, levers, nixpkgs
             , llvm-pretty-src
+            , fgl-src
+            , fgl-visualize-src
             }:
     let
       shellWith = pkgs: adds: drv: drv.overrideAttrs(old:
@@ -101,11 +111,18 @@
             [ llvm-pretty-bc-parser-test-build ];
           DOC = wrap "llvm-pretty-bc-parser-DOC"
             [ llvm-pretty-bc-parser-doc ];
+          fgl = mkHaskell "fgl" fgl-src {
+            adjustDrv = args: haskellAdj;
+          };
+          fgl-visualize = mkHaskell "fgl-visualize" fgl-visualize-src {
+            inherit fgl;
+            adjustDrv = args: haskellAdj;
+          };
           llvm-pretty = mkHaskell "llvm-pretty" llvm-pretty-src {
             adjustDrv = args: haskellAdj;
           };
           llvm-pretty-bc-parser = mkHaskell "llvm-pretty-bc-parser" self {
-            inherit llvm-pretty;
+            inherit llvm-pretty fgl fgl-visualize;
             adjustDrv = args: haskellAdj;
           };
           llvm-pretty-bc-parser-test-build = mkHaskell "llvm-pretty-bc-parser-test-build" self {

--- a/flake.nix
+++ b/flake.nix
@@ -97,6 +97,8 @@
                 pkgs.llvm_11
               ]
             );
+          TESTS_PREP = wrap "llvm-pretty-bc-parser-TESTS_PREP"
+            [ llvm-pretty-bc-parser-test-build ];
           DOC = wrap "llvm-pretty-bc-parser-DOC"
             [ llvm-pretty-bc-parser-doc ];
           llvm-pretty = mkHaskell "llvm-pretty" llvm-pretty-src {

--- a/llvm-pretty-bc-parser.cabal
+++ b/llvm-pretty-bc-parser.cabal
@@ -97,6 +97,11 @@ test-suite unit-test
     type:                exitcode-stdio-1.0
     main-is:             Main.hs
     other-modules:       Tests.Instances,
+                         Tests.ExpressionInstances,
+                         Tests.FuncDataInstances,
+                         Tests.PrimInstances,
+                         Tests.StmtInstances,
+                         Tests.TripleInstances,
                          Tests.Metadata
     hs-source-dirs:      unit-test
     default-language:    Haskell2010

--- a/unit-test/Tests/ExpressionInstances.hs
+++ b/unit-test/Tests/ExpressionInstances.hs
@@ -1,0 +1,43 @@
+module Tests.ExpressionInstances where
+
+import Generic.Random hiding ((%))
+import Test.QuickCheck.Arbitrary (Arbitrary(..))
+
+import Text.LLVM.AST
+
+import Tests.PrimInstances ()
+
+
+instance Arbitrary lab => Arbitrary (Type' lab)                       where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (Typed lab)                       where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (ValMd' lab)                      where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (Value' lab)                      where arbitrary = genericArbitrary uniform
+instance Arbitrary ArithOp                                            where arbitrary = genericArbitrary uniform
+instance Arbitrary UnaryArithOp                                       where arbitrary = genericArbitrary uniform
+instance Arbitrary BitOp                                              where arbitrary = genericArbitrary uniform
+instance Arbitrary ConvOp                                             where arbitrary = genericArbitrary uniform
+instance Arbitrary ICmpOp                                             where arbitrary = genericArbitrary uniform
+instance Arbitrary FCmpOp                                             where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DebugLoc' lab)                   where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (ConstExpr' lab)                  where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DebugInfo' lab)                  where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DIImportedEntity' lab)           where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DITemplateTypeParameter' lab)    where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DITemplateValueParameter' lab)   where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DINameSpace' lab)                where arbitrary = genericArbitrary uniform
+instance Arbitrary DIBasicType                                        where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DICompileUnit' lab)              where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DICompositeType' lab)            where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DIDerivedType' lab)              where arbitrary = genericArbitrary uniform
+instance Arbitrary DIExpression                                       where arbitrary = genericArbitrary uniform
+instance Arbitrary DIFile                                             where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DIGlobalVariable' lab)           where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DIGlobalVariableExpression' lab) where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DILexicalBlock' lab)             where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DILexicalBlockFile' lab)         where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DILocalVariable' lab)            where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DISubprogram' lab)               where arbitrary = genericArbitrary uniform
+instance Arbitrary DISubrange                                         where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DISubroutineType' lab)           where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DILabel' lab)                    where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (DIArgList' lab)                  where arbitrary = genericArbitrary uniform

--- a/unit-test/Tests/FuncDataInstances.hs
+++ b/unit-test/Tests/FuncDataInstances.hs
@@ -1,0 +1,24 @@
+module Tests.FuncDataInstances where
+
+import Generic.Random hiding ((%))
+import Test.QuickCheck.Arbitrary (Arbitrary(..))
+
+import Text.LLVM.AST
+
+import Tests.StmtInstances ()
+
+
+instance Arbitrary BlockLabel where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (BasicBlock' lab) where
+  arbitrary = genericArbitrary uniform
+
+instance Arbitrary TypeDecl where arbitrary = genericArbitrary uniform
+instance Arbitrary Global where arbitrary = genericArbitrary uniform
+instance Arbitrary GlobalAttrs where arbitrary = genericArbitrary uniform
+instance Arbitrary Linkage where arbitrary = genericArbitrary uniform
+instance Arbitrary Visibility where arbitrary = genericArbitrary uniform
+
+instance Arbitrary FunAttr where arbitrary = genericArbitrary uniform
+instance Arbitrary Define where arbitrary = genericArbitrary uniform
+instance Arbitrary Declare where arbitrary = genericArbitrary uniform
+instance Arbitrary GC     where arbitrary = genericArbitrary uniform

--- a/unit-test/Tests/Instances.hs
+++ b/unit-test/Tests/Instances.hs
@@ -1,7 +1,13 @@
 -- | Arbitrary instances for LLVM AST nodes, for QuickCheck.
 --
--- This module takes a long time to compile... small price to pay for not
--- writing instances.
+-- These declarations are actually spread across a number of files.  This spread
+-- must allow for dependencies between instances, which would not be as much of
+-- an issue if they were all collected in a single file, but the single file
+-- takes much more time and memory to compile.
+--
+-- In one file:                                  2m13s compilation, ~10GB RAM
+-- top + triple + prim + expr + stmt + funcdata:   32s compilation, ~ 1GB RAM
+
 module Tests.Instances where
 
 import Generic.Random hiding ((%))
@@ -9,83 +15,23 @@ import Test.QuickCheck.Arbitrary (Arbitrary(..))
 
 import Data.LLVM.Internal
 import Text.LLVM.AST
-import qualified Text.LLVM.Triple.AST as Triple
+
+import Tests.TripleInstances ()
+import Tests.FuncDataInstances ()
+import Tests.ExpressionInstances ()
+import Tests.StmtInstances ()
 
 -------------------------------------------------------------------------
 -- ** llvm-pretty
 
-instance Arbitrary Triple.Arch where arbitrary = genericArbitrary uniform
-instance Arbitrary Triple.Environment where arbitrary = genericArbitrary uniform
-instance Arbitrary Triple.OS where arbitrary = genericArbitrary uniform
-instance Arbitrary Triple.ObjectFormat where arbitrary = genericArbitrary uniform
-instance Arbitrary Triple.SubArch where arbitrary = genericArbitrary uniform
-instance Arbitrary Triple.TargetTriple where arbitrary = genericArbitrary uniform
-instance Arbitrary Triple.Vendor where arbitrary = genericArbitrary uniform
-
-instance Arbitrary Module                                             where arbitrary = genericArbitrary uniform
-instance Arbitrary NamedMd                                            where arbitrary = genericArbitrary uniform
-instance Arbitrary UnnamedMd                                          where arbitrary = genericArbitrary uniform
-instance Arbitrary GlobalAlias                                        where arbitrary = genericArbitrary uniform
-instance Arbitrary LayoutSpec                                         where arbitrary = genericArbitrary uniform
-instance Arbitrary Mangling                                           where arbitrary = genericArbitrary uniform
-instance Arbitrary SelectionKind                                      where arbitrary = genericArbitrary uniform
-instance Arbitrary PrimType                                           where arbitrary = genericArbitrary uniform
-instance Arbitrary FloatType                                          where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (Type' lab)                       where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (NullResult lab)                  where arbitrary = genericArbitrary uniform
-instance Arbitrary TypeDecl                                           where arbitrary = genericArbitrary uniform
-instance Arbitrary Global                                             where arbitrary = genericArbitrary uniform
-instance Arbitrary GlobalAttrs                                        where arbitrary = genericArbitrary uniform
-instance Arbitrary Declare                                            where arbitrary = genericArbitrary uniform
-instance Arbitrary Define                                             where arbitrary = genericArbitrary uniform
-instance Arbitrary FunAttr                                            where arbitrary = genericArbitrary uniform
-instance Arbitrary BlockLabel                                         where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (BasicBlock' lab)                 where arbitrary = genericArbitrary uniform
-instance Arbitrary Linkage                                            where arbitrary = genericArbitrary uniform
-instance Arbitrary Visibility                                         where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (Typed lab)                       where arbitrary = genericArbitrary uniform
-instance Arbitrary ArithOp                                            where arbitrary = genericArbitrary uniform
-instance Arbitrary UnaryArithOp                                       where arbitrary = genericArbitrary uniform
-instance Arbitrary BitOp                                              where arbitrary = genericArbitrary uniform
-instance Arbitrary ConvOp                                             where arbitrary = genericArbitrary uniform
-instance Arbitrary AtomicRWOp                                         where arbitrary = genericArbitrary uniform
-instance Arbitrary AtomicOrdering                                     where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (Instr' lab)                      where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (Clause' lab)                     where arbitrary = genericArbitrary uniform
-instance Arbitrary ICmpOp                                             where arbitrary = genericArbitrary uniform
-instance Arbitrary FCmpOp                                             where arbitrary = genericArbitrary uniform
-instance Arbitrary FP80Value                                          where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (Value' lab)                      where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (ValMd' lab)                      where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (DebugLoc' lab)                   where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (Stmt' lab)                       where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (ConstExpr' lab)                  where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (DebugInfo' lab)                  where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (DIImportedEntity' lab)           where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (DITemplateTypeParameter' lab)    where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (DITemplateValueParameter' lab)   where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (DINameSpace' lab)                where arbitrary = genericArbitrary uniform
-instance Arbitrary DIBasicType                                        where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (DICompileUnit' lab)              where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (DICompositeType' lab)            where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (DIDerivedType' lab)              where arbitrary = genericArbitrary uniform
-instance Arbitrary DIExpression                                       where arbitrary = genericArbitrary uniform
-instance Arbitrary DIFile                                             where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (DIGlobalVariable' lab)           where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (DIGlobalVariableExpression' lab) where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (DILexicalBlock' lab)             where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (DILexicalBlockFile' lab)         where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (DILocalVariable' lab)            where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (DISubprogram' lab)               where arbitrary = genericArbitrary uniform
-instance Arbitrary DISubrange                                         where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (DISubroutineType' lab)           where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (DILabel' lab)                    where arbitrary = genericArbitrary uniform
-instance Arbitrary lab => Arbitrary (DIArgList' lab)                  where arbitrary = genericArbitrary uniform
-
--- Newtypes
-instance Arbitrary Ident  where arbitrary = genericArbitrary uniform
-instance Arbitrary Symbol where arbitrary = genericArbitrary uniform
-instance Arbitrary GC     where arbitrary = genericArbitrary uniform
+instance Arbitrary Module where arbitrary = genericArbitrary uniform
+instance Arbitrary NamedMd where arbitrary = genericArbitrary uniform
+instance Arbitrary UnnamedMd where arbitrary = genericArbitrary uniform
+instance Arbitrary GlobalAlias where arbitrary = genericArbitrary uniform
+instance Arbitrary LayoutSpec where arbitrary = genericArbitrary uniform
+instance Arbitrary Mangling where arbitrary = genericArbitrary uniform
+instance Arbitrary SelectionKind where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (NullResult lab) where arbitrary = genericArbitrary uniform
 
 -------------------------------------------------------------------------
 -- ** llvm-pretty-bc-parser

--- a/unit-test/Tests/Metadata.hs
+++ b/unit-test/Tests/Metadata.hs
@@ -7,7 +7,8 @@ import Test.Tasty.HUnit (testCase, (@?=))
 import Data.LLVM.Internal
 import Text.LLVM.AST
 
-import Tests.Instances()
+import Tests.Instances ()
+
 
 tests :: TestTree
 tests = testGroup "Metadata"

--- a/unit-test/Tests/PrimInstances.hs
+++ b/unit-test/Tests/PrimInstances.hs
@@ -1,0 +1,13 @@
+module Tests.PrimInstances where
+
+import Generic.Random hiding ((%))
+import Test.QuickCheck.Arbitrary (Arbitrary(..))
+
+import Text.LLVM.AST
+
+
+instance Arbitrary PrimType where arbitrary = genericArbitrary uniform
+instance Arbitrary FloatType where arbitrary = genericArbitrary uniform
+instance Arbitrary FP80Value where arbitrary = genericArbitrary uniform
+instance Arbitrary Ident  where arbitrary = genericArbitrary uniform
+instance Arbitrary Symbol where arbitrary = genericArbitrary uniform

--- a/unit-test/Tests/StmtInstances.hs
+++ b/unit-test/Tests/StmtInstances.hs
@@ -1,0 +1,15 @@
+module Tests.StmtInstances where
+
+import Generic.Random hiding ((%))
+import Test.QuickCheck.Arbitrary (Arbitrary(..))
+
+import Text.LLVM.AST
+
+import Tests.ExpressionInstances ()
+
+
+instance Arbitrary AtomicRWOp where arbitrary = genericArbitrary uniform
+instance Arbitrary AtomicOrdering where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (Instr' lab) where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (Clause' lab) where arbitrary = genericArbitrary uniform
+instance Arbitrary lab => Arbitrary (Stmt' lab) where arbitrary = genericArbitrary uniform

--- a/unit-test/Tests/TripleInstances.hs
+++ b/unit-test/Tests/TripleInstances.hs
@@ -1,0 +1,15 @@
+module Tests.TripleInstances where
+
+import Generic.Random hiding ((%))
+import Test.QuickCheck.Arbitrary (Arbitrary(..))
+
+import qualified Text.LLVM.Triple.AST as Triple
+
+
+instance Arbitrary Triple.Arch where arbitrary = genericArbitrary uniform
+instance Arbitrary Triple.Environment where arbitrary = genericArbitrary uniform
+instance Arbitrary Triple.OS where arbitrary = genericArbitrary uniform
+instance Arbitrary Triple.ObjectFormat where arbitrary = genericArbitrary uniform
+instance Arbitrary Triple.SubArch where arbitrary = genericArbitrary uniform
+instance Arbitrary Triple.TargetTriple where arbitrary = genericArbitrary uniform
+instance Arbitrary Triple.Vendor where arbitrary = genericArbitrary uniform


### PR DESCRIPTION
This establishes another channel of CI using nix, which will be used in the future to run tests against multiple versions of llvm and clang.  This also updates some of the test code for easier and faster compilation.