### PR TITLE
disasm-test: Refactoring and runtime cleanup 

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc-version: [ "ghc94", "ghc92", "ghc810", "ghc88" ]
+        ghc-version: [ "ghc96", "ghc94", "ghc92", "ghc810", "ghc88" ]
     steps:
       - uses: cachix/install-nix-action@v20
         with:

--- a/disasm-test/Main.hs
+++ b/disasm-test/Main.hs
@@ -403,8 +403,8 @@ processLL pfx f = do
   Details dets <- gets showDetails
   when dets $ liftIO $ putStrLn (showString f ": ")
   X.handle logError $
-    withFile (generateBitCode  pfx f)  $ \ bc   ->
-    withFile (normalizeBitCode pfx bc) $ \ norm -> do
+    withFile (assembleToBitCode pfx f)  $ \ bc   ->
+    withFile (disasmBitCode pfx bc) $ \ norm -> do
       (parsed, ast) <- processBitCode pfx bc
       when dets $ liftIO $ do
         ignore (Proc.callProcess "diff" ["-u", norm, parsed])
@@ -432,8 +432,8 @@ type TestMonad a = StateT TestState IO a
 
 
 -- | Assemble some llvm assembly, producing a bitcode file in /tmp.
-generateBitCode :: FilePath -> FilePath -> TestMonad FilePath
-generateBitCode pfx file = do
+assembleToBitCode :: FilePath -> FilePath -> TestMonad FilePath
+assembleToBitCode pfx file = do
   tmp <- liftIO getTemporaryDirectory
   LLVMAs asm <- gets llvmAs
   X.bracketOnError
@@ -446,8 +446,8 @@ generateBitCode pfx file = do
 
 -- | Use llvm-dis to parse a bitcode file, to obtain a normalized version of the
 -- llvm assembly.
-normalizeBitCode :: FilePath -> FilePath -> TestMonad FilePath
-normalizeBitCode pfx file = do
+disasmBitCode :: FilePath -> FilePath -> TestMonad FilePath
+disasmBitCode pfx file = do
   tmp <- liftIO $ getTemporaryDirectory
   LLVMDis dis <- gets llvmDis
   X.bracketOnError

--- a/disasm-test/Main.hs
+++ b/disasm-test/Main.hs
@@ -567,9 +567,9 @@ with2Files :: TestM (FilePath, Maybe FilePath)
            -> ((FilePath, Maybe FilePath) -> TestM r)
            -> TestM r
 with2Files iofiles f =
-  let cleanup (tmp1, mbTmp2) = case mbTmp2 of
-                                 Nothing -> rmFile tmp1
-                                 Just t2 -> rmFile tmp1 >> rmFile t2
+  let cleanup (tmp1, mbTmp2) = do
+        rmFile tmp1
+        traverse rmFile mbTmp2
   in X.bracket iofiles cleanup f
 
 rmFile :: FilePath -> TestM ()

--- a/disasm-test/Main.hs
+++ b/disasm-test/Main.hs
@@ -544,5 +544,8 @@ callProc p args = -- putStrLn ("Calling process: " ++ p ++ " " ++ unwords args) 
 withFile :: TestMonad FilePath -> (FilePath -> TestMonad r) -> TestMonad r
 withFile iofile f =
   let cleanup tmp = do Keep keep <- gets keepTemp
-                       when keep $ liftIO $ removeFile tmp
+                       unless keep
+                         $ do Details dets <- gets showDetails
+                              when dets $ liftIO $ putStrLn $ "## Removing " <> tmp
+                              liftIO $ removeFile tmp
   in X.bracket iofile cleanup f

--- a/disasm-test/Main.hs
+++ b/disasm-test/Main.hs
@@ -497,11 +497,15 @@ processBitCode pfx file = do
       parsed <- liftIO $ printToTempFile "ll" (show (ppLLVM (ppModule m')))
       Roundtrip roundtrip <- gets rndTrip
       -- stripComments _keep parsed
+      Details det <- gets showDetails
       if roundtrip
       then do
         tmp2 <- liftIO $ printToTempFile "ast" (ppShow (normalizeModule m'))
+        when det $ liftIO $ putStrLn $ "## parsed Bitcode to " <> parsed <> " and " <> tmp2
         return (parsed, Just tmp2)
-      else return (parsed, Nothing)
+      else do
+        when det $ liftIO $ putStrLn $ "## parsed Bitcode to " <> parsed
+        return (parsed, Nothing)
 
 -- | Remove comments from a .ll file, stripping everything including the
 -- semi-colon.

--- a/llvm-pretty-bc-parser.cabal
+++ b/llvm-pretty-bc-parser.cabal
@@ -146,6 +146,7 @@ Test-suite disasm-test
                        tasty >= 1.3,
                        tasty-hunit,
                        tasty-sugar >= 2.2 && < 2.3,
+                       transformers >= 0.5 && < 0.7,
                        terminal-size >= 0.3 && < 0.4,
                        text,
                        versions < 7,

--- a/llvm-pretty-bc-parser.cabal
+++ b/llvm-pretty-bc-parser.cabal
@@ -135,6 +135,7 @@ Test-suite disasm-test
                        process,
                        directory,
                        bytestring,
+                       exceptions >= 0.10 && < 0.11,
                        filepath,
                        lens,
                        optparse-applicative >= 0.18.1.0,


### PR DESCRIPTION
This refactors the disasm-test to use a `StateT` monad over `IO` to carry the control information to where it is needed rather than passing it around as explicit arguments.  Output of the details of differences and operations executed is now hidden behind a `--details` flag, with more information available when using that flag.  This also ensures that all temporary files are cleaned up (there were a couple of different places where temporary files could be left behind).