### PR TITLE
Ensure test failures cause CI failures; add C++ test sources

### DIFF
--- a/disasm-test/Main.hs
+++ b/disasm-test/Main.hs
@@ -479,7 +479,15 @@ parseBC pfx bc = do
     Details dets <- gets showDetails
     when dets $ liftIO $ do
       -- Informationally display if there are differences between the llvm-dis
-      -- and llvm-disasm outputs, but no error if they differ.
+      -- and llvm-disasm outputs, but no error if they differ.  Note that the
+      -- arguments to this diff are not the same as those supplied to the diffCmp
+      -- function. The diff here is intended to supply additional information to
+      -- the user for diagnostics, and whitespace changes are likely unimportant
+      -- in that context; this diff does not determine the pass/fail status of
+      -- the testing.  On the other hand, the diffCmp *does* determine if the
+      -- tests pass or fail, so ignoring whitespace in that determination would
+      -- potentially weaken the testing to an unsatisfactory degree and would
+      -- need more careful evaluation.
       putStrLn "## Output differences: LLVM's llvm-dis <--> this llvm-disasm"
       ignore (Proc.callProcess "diff" ["-u", "-b", "-B", "-w", norm, parsed])
       putStrLn ("successfully parsed " ++ show pfx ++ " bitcode")

--- a/disasm-test/Main.hs
+++ b/disasm-test/Main.hs
@@ -476,7 +476,8 @@ parseBC pfx bc = do
     when dets $ liftIO $ do
       -- Informationally display if there are differences between the llvm-dis
       -- and llvm-disasm outputs, but no error if they differ.
-      ignore (Proc.callProcess "diff" ["-u", norm, parsed])
+      putStrLn "## Output differences: LLVM's llvm-dis <--> this llvm-disasm"
+      ignore (Proc.callProcess "diff" ["-u", "-b", "-B", "-w", norm, parsed])
       putStrLn ("successfully parsed " ++ show pfx ++ " bitcode")
     return (parsed, ast)
 

--- a/disasm-test/Main.hs
+++ b/disasm-test/Main.hs
@@ -20,7 +20,7 @@ import           Data.Bifunctor (first)
 import qualified Data.ByteString.Lazy as L
 import           Data.Char (ord,isLetter,isSpace,chr)
 import           Data.Generics (everywhere, mkT) -- SYB
-import           Data.List ( find, isInfixOf, isPrefixOf, nub, sort )
+import           Data.List ( find, isInfixOf, isPrefixOf, isSuffixOf, nub, sort )
 import           Data.Map ( (!), (!?) )
 import qualified Data.Map as Map
 import           Data.Maybe ( fromMaybe )
@@ -211,7 +211,7 @@ disasmTestIngredients =
                    , TO.Option (Proxy @Keep)
                    , TO.Option (Proxy @Details)
                    ] :
-  TS.sugarIngredients [ assemblyCube, compilerCube ]
+  TS.sugarIngredients [ assemblyCube, cCompilerCube, ccCompilerCube ]
   <> defaultIngredients
 
 parseCmdLine :: IO TO.OptionSet
@@ -326,11 +326,14 @@ main =  do
 
   knownBugs <- getKnownBugs
   sweets1 <- TS.findSugar assemblyCube
-  sweets2 <- TS.findSugar compilerCube
+  sweets2 <- TS.findSugar cCompilerCube
+  sweets3 <- TS.findSugar ccCompilerCube
   atests <- TS.withSugarGroups sweets1 testGroup
             $ \s _ e -> runAssemblyTest knownBugs s e
   ctests <- TS.withSugarGroups sweets2 testGroup
             $ \s _ e -> runCompileTest knownBugs s e
+  cctests <- TS.withSugarGroups sweets3 testGroup
+             $ \s _ e -> runCompileTest knownBugs s e
   let tests = atests <> ctests
   case TR.tryIngredients
          disasmTestIngredients
@@ -338,6 +341,7 @@ main =  do
          (testGroup "Disassembly tests"
           [ testGroup (showVC llvmAsVC) atests
           , testGroup (showVC clangVC) ctests
+          , testGroup (showVC clangVC) cctests
           ]) of
     Nothing ->
       hPutStrLn IO.stderr
@@ -493,16 +497,21 @@ parseBC pfx bc = do
 -- clang-generated bitcode will contain version-current output which might have
 -- newer elements and ordering.
 --
--- The compilerCube uses .c files as the input, and .ll files for the expected
--- output.  The assemblyCube uses the .ll file as both input and output.  The
--- actual testing done is very similar, and the assemblyCube always generates a
--- superset of the compilerCube tests (i.e. when no .c file is present).
+-- The cCompilerCube uses .c (C source) files as the input and .ll files for the
+-- expected output.  The ccCompilerCube uses .cc (C++ source) files as the input
+-- and .ll files for the expected output.  The assemblyCube uses the .ll file as
+-- both input and output.  The actual testing done is very similar, and the
+-- assemblyCube always generates a superset of the compilerCube tests (i.e. when
+-- no .c or .cc file is present).
 
-compilerCube :: TS.CUBE
-compilerCube = assemblyCube
-               { TS.rootName = "*.c"
-               , TS.sweetAdjuster = rangeMatch
-               }
+cCompilerCube :: TS.CUBE
+cCompilerCube = assemblyCube
+                { TS.rootName = "*.c"
+                , TS.sweetAdjuster = rangeMatch
+                }
+
+ccCompilerCube :: TS.CUBE
+ccCompilerCube = cCompilerCube { TS.rootName = "*.cc"}
 
 
 runCompileTest :: KnownBugs -> TS.Sweets -> TS.Expectation -> IO [TestTree]
@@ -593,7 +602,8 @@ assembleToBitCode pfx file = do
 compileToBitCode :: FilePath -> FilePath -> TestM FilePath
 compileToBitCode pfx file = do
   tmp <- liftIO getTemporaryDirectory
-  Clang comp <- gets clang
+  Clang comp' <- gets clang
+  let comp = if ".cc" `isSuffixOf` file then comp' <> "++" else comp'
   X.bracketOnError
     (liftIO $ openBinaryTempFile tmp (pfx <.> "bc"))
     (\(bc,_) -> do exists <- liftIO $ doesFileExist bc

--- a/flake.nix
+++ b/flake.nix
@@ -113,8 +113,12 @@
                        ''
                        ${pkgs.coreutils}/bin/cp -r ${built}/test-build/* .
                        export PATH=${llvm}/bin:${pkgs.diffutils}/bin:$PATH
+                       set -e
+                       echo Running unit-test
                        ./dist/build/unit-test/unit-test
+                       echo Running disasm-test
                        ./dist/build/disasm-test/disasm-test
+                       echo Finished testing
                        echo OK > $out
                        ''
                      ];
@@ -163,6 +167,7 @@
                     cp llvm-pretty-bc-parser.cabal $out/test-build
                     mkdir $out/test-build/disasm-test
                     cp -r disasm-test/tests $out/test-build/disasm-test
+                    cp -r disasm-test/known_bugs $out/test-build/disasm-test
                     cp -r dist $out/test-build/
                     '';
                 });

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
   # nix develop
   # nix run .  [runs llvm-disasm]
   #
-  # nix run github:galoisinc/llvm-pretty   [runs llvm-disasm]
+  # nix run github:galoisinc/llvm-pretty-bc-parser   [runs llvm-disasm]
 
   description = "Flake to build the haskell-src package 'llvm-pretty-bc-parser' and dependencies";
 
@@ -91,7 +91,7 @@
                   (pkgs.lib.genAttrs names (oneshell s))
                   [ "ghc" ];
                 shells = pkgs.lib.attrsets.mapAttrs (n: v: v.default) outs;
-            in shells
+            in shells // { default = devShells.${s}.llvm-pretty-bc-parser-test-build; }
           ) ;
 
       packages = levers.eachSystem (system:
@@ -121,7 +121,7 @@
               buildInputs = [ llvm pkgs.diffutils pkgs.coreutils ];
             };
         in rec {
-          default = llvm-pretty-bc-parser-test-build;
+          default = llvm-pretty-bc-parser;
           TESTS = wrap "llvm-pretty-bc-parser-TESTS"
             (builtins.map
               (llvm-pretty-bc-parser-test llvm-pretty-bc-parser-test-build)

--- a/flake.nix
+++ b/flake.nix
@@ -104,15 +104,17 @@
           haskellAdj = drv:
             with (pkgs.haskell).lib;
             dontHaddock (dontCheck (dontBenchmark (drv)));
-          llvm-pretty-bc-parser-test = built: llvm:
-            derivation {
+          llvm-pretty-bc-parser-test = built: llvmver:
+            let llvm = pkgs."llvm_${llvmver}";
+                clang = pkgs."clang_${llvmver}";
+            in derivation {
               inherit system;
-              name = "llvm-pretty-bc-parser-test-with-llvm${llvm.version}";
+              name = "llvm-pretty-bc-parser-test-with-llvm${llvmver}";
               builder = "${pkgs.bash}/bin/bash";
               args = [ "-c"
                        ''
                        ${pkgs.coreutils}/bin/cp -r ${built}/test-build/* .
-                       export PATH=${llvm}/bin:${pkgs.diffutils}/bin:$PATH
+                       export PATH=${llvm}/bin:${clang}/bin:${pkgs.diffutils}/bin:$PATH
                        set -e
                        echo Running unit-test
                        ./dist/build/unit-test/unit-test
@@ -122,7 +124,7 @@
                        echo OK > $out
                        ''
                      ];
-              buildInputs = [ llvm pkgs.diffutils pkgs.coreutils ];
+              buildInputs = [ clang llvm pkgs.diffutils pkgs.coreutils ];
             };
         in rec {
           default = llvm-pretty-bc-parser;
@@ -133,8 +135,8 @@
                 # NOTE: this is the main location which determines what LLVM
                 # versions are tested.  The default is to run each of the listed
                 # LLVM versions here in parallel.
-                pkgs.llvm_10
-                pkgs.llvm_11
+                "10"
+                "11"
               ]
             );
           TESTS_PREP = wrap "llvm-pretty-bc-parser-TESTS_PREP"


### PR DESCRIPTION
* Fixes the nix flake-based testing to cause the test run to fail when any of the individual tests failed.
* Adds the ability to have .cc input files (C++) for disasm-test runs, and ensures clang/clang++ is available when running the tests.
* Informational output and diffs generated bi disasm-test now ignore blank lines and whitespace in diff reporting.  This has no effect on whether the test passes or fails, it is simply diagnostic information reported to the user.
