### PR TITLE
Specify actual LLVM version for llvm-disasm and disasm-tests

### DIFF
--- a/disasm-test/Main.hs
+++ b/disasm-test/Main.hs
@@ -683,8 +683,9 @@ processBitCode pfx file = do
       llvmVersion <- gets llvmVer
       llvmAssembly <-
         case vcVersioning llvmVersion ^? (_Right . major) of
-          Nothing -> do liftIO $ putStrLn ( "warning: unknown LLVM version ("
-                                            <> showVC llvmVersion <> "), assuming 3.5")
+          Nothing -> do liftIO $ hPutStrLn IO.stderr
+                          ( "warning: unknown LLVM version ("
+                            <> showVC llvmVersion <> "), assuming 3.5")
                         return $ ppLLVM35 $ llvmPP m'
           Just v ->
             case v of

--- a/disasm-test/Main.hs
+++ b/disasm-test/Main.hs
@@ -697,7 +697,7 @@ processBitCode pfx file = do
                      o -> if maybe True (< 5) o
                           then return $ ppLLVM35 $ llvmPP m'
                           else return $ ppLLVM38 $ llvmPP m'
-              _ -> return $ ppLLVM38 $ llvmPP m'  -- TODO: LLVM38 is the last one currently defined
+              _ -> return $ ppLLVM (fromEnum v) $ llvmPP m'
       parsed <- liftIO $ printToTempFile "ll" $ show llvmAssembly
       Roundtrip roundtrip <- gets rndTrip
       -- stripComments parsed

--- a/disasm-test/Main.hs
+++ b/disasm-test/Main.hs
@@ -8,7 +8,7 @@ module Main where
 
 import           Data.LLVM.BitCode (parseBitCodeLazyFromFile,Error(..),formatError)
 import qualified Text.LLVM.AST as AST
-import           Text.LLVM.PP
+import           Text.LLVM.PP ( ppLLVM, ppLLVM35, ppLLVM36, ppLLVM37, ppLLVM38, llvmPP )
 
 import qualified Control.Exception as EX
 import           Control.Lens ( (^?), _Right )

--- a/flake.lock
+++ b/flake.lock
@@ -110,11 +110,11 @@
     "llvm-pretty-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1691168617,
-        "narHash": "sha256-vP0M0M83NBQ3H9HjgZwRYiUc6IZaYMqTDZMoWSovvKU=",
+        "lastModified": 1691429801,
+        "narHash": "sha256-9fsBcc1onTSTumGoAyxQC438j/7tQlMEJNvhKvzSgV0=",
         "owner": "elliottt",
         "repo": "llvm-pretty",
-        "rev": "f94af7fbc43b05a44c04bd2f1de64fe435858c3e",
+        "rev": "e586747ce3f4a37245b56745b90d4c1c02423baf",
         "type": "github"
       },
       "original": {

--- a/llvm-disasm/LLVMDis.hs
+++ b/llvm-disasm/LLVMDis.hs
@@ -1,16 +1,14 @@
-{-# LANGUAGE ImplicitParams #-}
-{-# LANGUAGE MultiWayIf #-}
-
 import Data.LLVM.BitCode (parseBitCode, formatError)
 import Data.LLVM.CFG (buildCFG, CFG(..), blockId)
 import Text.LLVM.AST (defBody, modDefines,Module)
-import Text.LLVM.PP (ppLLVM35, ppLLVM36, ppLLVM37, ppLLVM38, llvmPP)
-import Text.PrettyPrint (Style(..), renderStyle, style)
+import Text.LLVM.PP (ppLLVM, ppLLVM35, ppLLVM36, ppLLVM37, ppLLVM38, llvmPP, llvmVlatest)
 
 import Control.Monad (when)
 import Data.Graph.Inductive.Graph (nmap, emap)
 import Data.Graph.Inductive.Dot (fglToDotString, showDot)
 import Data.Monoid (Endo(..))
+import Text.PrettyPrint (Style(..), renderStyle, style)
+import Text.Read (readMaybe)
 import Text.Show.Pretty (pPrint)
 import System.Console.GetOpt
   (ArgOrder(..), ArgDescr(..), OptDescr(..), getOpt, usageInfo)
@@ -28,7 +26,7 @@ data Options = Options {
 
 defaultOptions :: Options
 defaultOptions  = Options {
-    optLLVMVersion = "3.8"
+    optLLVMVersion = show llvmVlatest
   , optDoCFG       = False
   , optAST         = False
   , optHelp        = False
@@ -37,7 +35,7 @@ defaultOptions  = Options {
 options :: [OptDescr (Endo Options)]
 options  =
   [ Option "" ["llvm-version"] (ReqArg setLLVMVersion "VERSION")
-    "print assembly compatible with this LLVM version (e.g., 3.8)"
+    "output for LLVM version (e.g., 3.5, 3.6. 3.7, 3.8, 4, 5, 6, ...)."
   , Option "" ["cfg"] (NoArg setDoCFG)
     "output CFG in graphviz format"
   , Option "" ["ast"] (NoArg setAST)
@@ -102,23 +100,15 @@ renderLLVM opts m = do
   let s         = style { lineLength = maxBound, ribbonsPerLine = 1.0 }
   let v         = optLLVMVersion opts
   let putRender = putStrLn . renderStyle s
-  if -- try the 3.5 style for 3.4
-     | v == "3.4"            -> putRender (ppLLVM35 (llvmPP m))
-     | v == "3.5"            -> putRender (ppLLVM35 (llvmPP m))
-     | v == "3.6"            -> putRender (ppLLVM36 (llvmPP m))
-     | v == "3.7"            -> putRender (ppLLVM37 (llvmPP m))
-     | v == "3.8"            -> putRender (ppLLVM38 (llvmPP m))
-     -- try the 3.8 style for 3.9-11.0
-     | v == "3.9"            -> putRender (ppLLVM38 (llvmPP m))
-     | v `elem` ["4", "4.0"] -> putRender (ppLLVM38 (llvmPP m))
-     | v `elem` ["5", "5.0"] -> putRender (ppLLVM38 (llvmPP m))
-     | v `elem` ["6", "6.0"] -> putRender (ppLLVM38 (llvmPP m))
-     | v `elem` ["7", "7.0"] -> putRender (ppLLVM38 (llvmPP m))
-     | v `elem` ["8", "8.0"] -> putRender (ppLLVM38 (llvmPP m))
-     | v `elem` ["9", "9.0"] -> putRender (ppLLVM38 (llvmPP m))
-     | v `elem` ["10", "10.0"] -> putRender (ppLLVM38 (llvmPP m))
-     | v `elem` ["11", "11.0"] -> putRender (ppLLVM38 (llvmPP m))
-     | otherwise -> printUsage ["unsupported LLVM version: " ++ v] >> exitFailure
+  case readMaybe v :: Maybe Int of
+    Just n -> putRender (ppLLVM n (llvmPP m))
+    Nothing -> case readMaybe v :: Maybe Float of
+                 Just 3.4 -> putRender (ppLLVM35 (llvmPP m))
+                 Just 3.5 -> putRender (ppLLVM35 (llvmPP m))
+                 Just 3.6 -> putRender (ppLLVM36 (llvmPP m))
+                 Just 3.7 -> putRender (ppLLVM37 (llvmPP m))
+                 Just 3.8 -> putRender (ppLLVM38 (llvmPP m))
+                 _ -> printUsage ["unsupported LLVM version: " ++ v] >> exitFailure
   when (optDoCFG opts) $ do
     let cfgs  = map (buildCFG . defBody) $ modDefines m
         fixup = nmap (show . blockId) . emap (const "")

--- a/llvm-disasm/LLVMDis.hs
+++ b/llvm-disasm/LLVMDis.hs
@@ -59,8 +59,16 @@ getOptions =
 printUsage :: [String] -> IO ()
 printUsage errs =
   do prog <- getProgName
-     let banner = "Usage: " ++ prog ++ " [OPTIONS]"
-     putStrLn (usageInfo (unlines (errs ++ [banner])) options)
+     let banner = [ "Usage: " ++ prog ++ " [OPTIONS]"
+                  , ""
+                  , "  Converts LLVM bitcode format (.bc) to LLVM text form (.ll) on stdout."
+                  , "  Supports LLVM versions 3.4 through " <> show llvmVlatest <> "."
+                  , ""
+                  , "  Comparable to the llvm-dis tool from LLVM (which only supports"
+                  , "  the *current* version) but writes to stdout instead of a file."
+                  ]
+
+     putStrLn (usageInfo (unlines (errs ++ banner)) options)
 
 setLLVMVersion :: String -> Endo Options
 setLLVMVersion str = Endo (\opt -> opt { optLLVMVersion = str })

--- a/llvm-pretty-bc-parser.cabal
+++ b/llvm-pretty-bc-parser.cabal
@@ -70,7 +70,7 @@ Library
                        bytestring  >= 0.10,
                        containers  >= 0.4,
                        fgl         >= 5.5,
-                       llvm-pretty >= 0.11.0.0.99 && < 0.12,
+                       llvm-pretty >= 0.11.0.0.100 && < 0.12,
                        mtl         >= 2.2.2,
                        pretty      >= 1.0.1,
                        uniplate    >= 1.6,

--- a/src/Data/LLVM/BitCode/IR/Function.hs
+++ b/src/Data/LLVM/BitCode/IR/Function.hs
@@ -32,18 +32,19 @@ import qualified Data.Sequence as Seq
 import qualified Data.Traversable as T
 
 
--- When showing a Symbol to the user, show it in the manner that it would appear
--- in LLVM text format.
---
+-- | When showing a Symbol to the user, show it in the manner that it would appear
+-- in LLVM text format.  This displays the Symbol in the format associated with
+-- the latest version of LLVM supported by llvm-pretty and this library; the
+-- Symbol syntax has not changed from LLVM 3.5 through LLVM 16, and this library
+-- is intended to be able to import *any* version of LLVM, so this is not a
+-- significant issue that would drive the code changes necessary to make an
+-- actual LLVM version available here.
+
 -- NOTE: this cannot be eta-reduced to point-free format because simplified
 -- subsumption rules (introduced in GHC 9) requires eta-expansion of some higher
 -- order functions in order to maintain soundness and typecheck.
---
--- TODO: this shows it in the manner that LLVM v3.5 would
--- display the Symbol, but it should actually display the Symbol in the format of
--- the current LLVM version being disassembled.
 prettySym :: Symbol -> String
-prettySym s = show $ ppLLVM $ llvmPP s
+prettySym s = show $ ppLLVM llvmVlatest $ llvmPP s
 
 
 -- Function Aliases ------------------------------------------------------------

--- a/src/Data/LLVM/BitCode/Parse.hs
+++ b/src/Data/LLVM/BitCode/Parse.hs
@@ -569,7 +569,7 @@ getTypeId n = do
   symtab <- getTypeSymtab
   case Map.lookup n (tsByName symtab) of
     Just ix -> return ix
-    Nothing -> fail ("unknown type alias " ++ show (ppLLVM (ppIdent n)))
+    Nothing -> fail ("unknown type alias " ++ show (ppLLVM llvmVlatest (llvmPP n)))
 
 
 -- Value Symbol Table ----------------------------------------------------------


### PR DESCRIPTION
The `llvm-pretty` library now allows for specification of the actual LLVM version for desired output (previously, only 3.5, 3.6, 3.7, and 3.8 could be explicitly specified, and higher versions simply utilized the 3.8 output format), so the tests and llvm-disasm tool now support that full range.