### PR TITLE
Add Issue #123 test and known_bug entry: global variable declarations

### DIFF
--- a/disasm-test/known_bugs/issue222_global-var
+++ b/disasm-test/known_bugs/issue222_global-var
@@ -1,0 +1,5 @@
+##> rootMatchName: global-var.c
+##> llvmver: 10
+##> summary: unnamed metadata indices problem
+
+This is another manifestation of Issue #222.

--- a/disasm-test/known_bugs/llvm-pretty_issue123
+++ b/disasm-test/known_bugs/llvm-pretty_issue123
@@ -1,0 +1,42 @@
+##> rootMatchName: global-var.c
+##> summary: global variables tagged as external AND initialized
+##> llvmver: 11 12 13 14 15
+
+## Running: llvm-as -o /tmp/nix-shell.UBduFW/global-var.pre-llvm10136388-9.bc /tmp/nix-shell.UBduFW/global-var.pre-llvm10llvm-disasm136388-7.ll
+llvm-as: /tmp/nix-shell.UBduFW/global-var.pre-llvm10llvm-disasm136388-7.ll:4:43: error: expected top-level entity
+@global_var = external default global i32 0, align 4
+                                          ^
+FAIL
+          Exception: callProcess: llvm-as "-o" "/tmp/nix-shell.UBduFW/global-var.pre-llvm10136388-9.bc" "/tmp/nix-shell.UBduFW/global-var.pre-llvm10llvm-disasm136388-7.ll" (exit 1): failed
+          Use -p '/global-var/&&/global-var.pre-llvm10/' to rerun this test only.
+
+
+Examining the output, llvm-dis produces:
+
+@global_var = common global i32 0, align 4
+
+but llvm-disasm from this package produces:
+
+@global_var = external default global i32 0, align 4
+
+----------
+
+When clang-v9 or clang-v10 compiles, the output is:
+
+llvm-dis:    @global_var = common global i32 0, align 4, !dbg !0
+llvm-disasm: @global_var = common default global i32 0, align 4, !dbg !4
+
+Then this is llvm-as and the result of the round trip is:
+
+llvm-dis:    @global_var = common global i32 0, align 4, !dbg !0
+llvm-disasm: @global_var = common default global i32 0, align 4, !dbg !4
+
+----------
+
+with clang-11, the output is:
+
+llvm-dis:    @global_var = global i32 0, align 4, !dbg !0
+llvm-disasm: @global_var = external default global i32 0, align 4, !dbg !4
+
+The latter fails, presumably because it's not valid to initialize an external.
+Starting with clang-11, the "common" is dropped as the expected default.

--- a/disasm-test/known_bugs/llvm-pretty_issue123_ll
+++ b/disasm-test/known_bugs/llvm-pretty_issue123_ll
@@ -1,0 +1,6 @@
+##> rootMatchName: global-var.ll
+##> summary: global variables tagged as external AND initialized
+
+This is identical to llvm-pretty_issue123, but since the input is .ll, it never
+varies and therefore fails for all versions of LLVM (thus, this known_bugs file
+has no llvmver restrictions.

--- a/disasm-test/tests/global-var-extern.c
+++ b/disasm-test/tests/global-var-extern.c
@@ -1,0 +1,3 @@
+extern int global_var;
+
+int foo(void) { return global_var; }

--- a/disasm-test/tests/global-var-extern.ll
+++ b/disasm-test/tests/global-var-extern.ll
@@ -1,0 +1,32 @@
+; ModuleID = '/tmp/nix-shell.AkHqe1/global-var-extern207140-4.bc'
+source_filename = "disasm-test/tests/global-var-extern.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu-"
+
+@global_var = external global i32, align 4
+
+define i32 @foo() !dbg !9 {
+  %1 = load i32, i32* @global_var, align 4, !dbg !14
+  ret i32 %1, !dbg !15
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.ident = !{!2}
+!llvm.module.flags = !{!3, !4, !5, !6, !7, !8}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 15.0.7", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "disasm-test/tests/global-var-extern.c", directory: "/home/kquick/work/RISE/llvm-regr5")
+!2 = !{!"clang version 15.0.7"}
+!3 = !{i32 7, !"Dwarf Version", i32 5}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{i32 7, !"PIC Level", i32 2}
+!7 = !{i32 7, !"uwtable", i32 2}
+!8 = !{i32 7, !"frame-pointer", i32 2}
+!9 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 3, type: !10, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !13)
+!10 = distinct !DISubroutineType(types: !11)
+!11 = !{!12}
+!12 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!13 = !{}
+!14 = !DILocation(line: 3, column: 24, scope: !9)
+!15 = !DILocation(line: 3, column: 17, scope: !9)

--- a/disasm-test/tests/global-var.c
+++ b/disasm-test/tests/global-var.c
@@ -1,0 +1,1 @@
+int global_var;

--- a/disasm-test/tests/global-var.ll
+++ b/disasm-test/tests/global-var.ll
@@ -1,0 +1,13 @@
+; ModuleID = 'global-var.bc'
+source_filename = "disasm-test/tests/global-var.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+@global_var = global i32 0, align 4
+
+!llvm.module.flags = !{!0, !1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"PIC Level", i32 2}
+!2 = !{!"clang version 11.1.0"}


### PR DESCRIPTION
When a global variable is defined, it is erroneously tagged as external.

When a global variable is declared (external) the external tag is correctly supplied.
