### PR TITLE
Fix parsing for DwarfAddressSpace for DIDerivedType.

### DIFF
--- a/disasm-test/known_bugs/pr223pr228.txt
+++ b/disasm-test/known_bugs/pr223pr228.txt
@@ -1,5 +1,5 @@
-##> rootMatchName: p0.ll
-##> rootMatchName: p0.c
+##> rootMatchName: p0.ll cmpxchg.ll
+##> rootMatchName: p0.c cmpxchg.c
 ##> summary: unnamed metadata indices are currently duplicated
 
 https://github.com/GaloisInc/llvm-pretty-bc-parser/pull/223

--- a/disasm-test/known_bugs/pr223pr228.txt
+++ b/disasm-test/known_bugs/pr223pr228.txt
@@ -1,5 +1,5 @@
 ##> rootMatchName: p0.ll
-##> rootMatchName: p0.c T189.c
+##> rootMatchName: p0.c
 ##> summary: unnamed metadata indices are currently duplicated
 
 https://github.com/GaloisInc/llvm-pretty-bc-parser/pull/223

--- a/src/Data/LLVM/BitCode/IR/Metadata.hs
+++ b/src/Data/LLVM/BitCode/IR/Metadata.hs
@@ -614,7 +614,8 @@ parseMetadataEntry vt mt pm (fromEntry -> Just r) =
              then pure Nothing  -- field not present
              else do v <- parseField r 12 numeric
                      -- dwarf address space is encoded in bitcode as +1; a value
-                     -- of zero means there is no dwarf address space present.
+                     -- of zero means there is no dwarf address space present:
+                     -- https://github.com/llvm/llvm-project/blob/bbe8cd1/llvm/lib/Bitcode/Reader/MetadataLoader.cpp#L1544-L1548
                      -- The AST representation is the actual address space, or
                      -- Nothing if there is no address space (indistinguishable
                      -- from "field not present" for LLVM 4 and earlier).

--- a/src/Data/LLVM/BitCode/IR/Metadata.hs
+++ b/src/Data/LLVM/BitCode/IR/Metadata.hs
@@ -611,8 +611,16 @@ parseMetadataEntry vt mt pm (fromEntry -> Just r) =
         <*> parseField r 10 numeric                                 -- didtFlags
         <*> (mdForwardRefOrNull ctx mt <$> parseField r 11 numeric) -- didtExtraData
         <*> (if length (recordFields r) <= 12
-             then pure Nothing
-             else Just                 <$> parseField r 12 numeric) -- didtDwarfAddressSpace
+             then pure Nothing  -- field not present
+             else do v <- parseField r 12 numeric
+                     -- dwarf address space is encoded in bitcode as +1; a value
+                     -- of zero means there is no dwarf address space present.
+                     -- The AST representation is the actual address space, or
+                     -- Nothing if there is no address space (indistinguishable
+                     -- from "field not present" for LLVM 4 and earlier).
+                     if v == 0
+                       then return Nothing
+                       else return $ Just $ v - 1)
         <*> (if length (recordFields r) <= 13
              then pure Nothing
              else mdForwardRefOrNull ctx mt <$> parseField r 13 numeric) -- didtAnnotations


### PR DESCRIPTION
In the bitcode, the address space is encoded as +1, where 0 means there is no address space.  This parsing will store the actual address space in the AST and use `Nothing` to indicate the "no address space" condition.  Note that this latter is indistinguishable from "not specified" for LLVM 4 and earlier, but this is not expected to be a significant distinction.

Supercedes https://github.com/elliottt/llvm-pretty/pull/125.