### PR TITLE
Build with additional warnings and disable _FORTIFY_SOURCE for tests.

### DIFF
--- a/disasm-test/Main.hs
+++ b/disasm-test/Main.hs
@@ -681,7 +681,7 @@ compileToBitCode pfx file = do
     (rmFile . fst)
     $ \(bc,h) ->
         do liftIO $ hClose h
-           callProc comp ["-c", "-emit-llvm", "-O0", "-g", "-o", bc, file]
+           callProc comp ["-c", "-emit-llvm", "-O0", "-U_FORTIFY_SOURCE", "-g", "-o", bc, file]
            return bc
 
 -- | Use llvm-dis to parse a bitcode file, to obtain a normalized version of the

--- a/flake.nix
+++ b/flake.nix
@@ -125,6 +125,7 @@
                        ''
                      ];
               buildInputs = [ clang llvm pkgs.diffutils pkgs.coreutils ];
+              hardeningDisable = [ "all" ];  # tests will build with -O0
             };
         in rec {
           default = llvm-pretty-bc-parser;

--- a/llvm-pretty-bc-parser.cabal
+++ b/llvm-pretty-bc-parser.cabal
@@ -61,8 +61,13 @@ Library
 
   Ghc-options:         -Wall
                        -Wunbanged-strict-patterns
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wsimplifiable-class-constraints
+                       -Wpartial-fields
                        -O2
                        -funbox-strict-fields
+                       -fhide-source-paths
 
   Build-depends:       array       >= 0.3,
                        base        >= 4.8 && < 5,


### PR DESCRIPTION
Some compiler configurations are set to automatically attempt to _FORTIFY_SOURCE which adds some verifications to the build, but only when optimization is enabled.  When the disasm-test builds with `-O0` to obtain direct bitcode translations, this can cause spurious warnings to be emitted during the testing process.

Also, enable some additional warnings (and make the compilation output quieter) for building the library.
