### PR TITLE
Parse constant cmp operand IDs using absolute encoding

### DIFF
--- a/disasm-test/tests/T266-constant-icmp.ll
+++ b/disasm-test/tests/T266-constant-icmp.ll
@@ -1,0 +1,7 @@
+@global_var = external constant [1 x i8]
+
+define i64 @h() {
+  br i1 icmp ne (i32 ptrtoint (ptr @global_var to i32), i32 1), label %pc_1, label %pc_1
+pc_1:
+  ret i64 0
+}

--- a/disasm-test/tests/T266-constant-icmp.pre-llvm15.ll
+++ b/disasm-test/tests/T266-constant-icmp.pre-llvm15.ll
@@ -1,0 +1,7 @@
+@global_var = external constant [1 x i8]
+
+define i64 @h() {
+  br i1 icmp ne (i32 ptrtoint ([1 x i8]* @global_var to i32), i32 1), label %pc_1, label %pc_1
+pc_1:
+  ret i64 0
+}

--- a/src/Data/LLVM/BitCode/IR/Constants.hs
+++ b/src/Data/LLVM/BitCode/IR/Constants.hs
@@ -8,7 +8,6 @@ module Data.LLVM.BitCode.IR.Constants where
 
 import qualified Data.LLVM.BitCode.Assert as Assert
 import           Data.LLVM.BitCode.Bitstream
-import           Data.LLVM.BitCode.IR.Values
 import           Data.LLVM.BitCode.Match
 import           Data.LLVM.BitCode.Parse
 import           Data.LLVM.BitCode.Record
@@ -345,9 +344,12 @@ parseConstantEntry t (getTy,cs) (fromEntry -> Just r) =
   -- [opty, opval, opval, pred]
   17 -> label "CST_CODE_CE_CMP" $ do
     let field = parseField r
-    opty <- getType                  =<< field 0 numeric
-    op0  <- getConstantFwdRefAdjustedId t opty =<< field 1 numeric
-    op1  <- getConstantFwdRefAdjustedId t opty =<< field 2 numeric
+    opty <- getType =<< field 0 numeric
+    ix0  <- field 1 numeric
+    ix1  <- field 2 numeric
+    cxt  <- getContext
+    let op0 = forwardRef cxt ix0 t
+    let op1 = forwardRef cxt ix1 t
 
     let isFloat = isPrimTypeOf isFloatingPoint
     cst <- if isFloat opty || isVectorOf isFloat opty

--- a/src/Data/LLVM/BitCode/IR/Values.hs
+++ b/src/Data/LLVM/BitCode/IR/Values.hs
@@ -2,7 +2,6 @@
 
 module Data.LLVM.BitCode.IR.Values (
     getValueTypePair
-  , getConstantFwdRefAdjustedId
   , getValue
   , getFnValueById, getFnValueById'
   , parseValueSymbolTableBlock
@@ -18,18 +17,6 @@ import Control.Monad ((<=<),foldM)
 
 
 -- Value Table -----------------------------------------------------------------
-
-getConstantFwdRefAdjustedId :: ValueTable -> Type -> Int -> Parse (Typed PValue)
-getConstantFwdRefAdjustedId t ty n' = label "getConstantFwdRefAdjustedId" $ do
-  mb <- lookupValue n'
-  case mb of
-    Just tv -> return tv
-
-    -- forward reference
-    Nothing -> do
-      cxt <- getContext
-      let ref = forwardRef cxt n' t
-      return (Typed ty (typedValue ref))
 
 -- | Get either a value from the value table, with its value, or parse a value
 -- and a type.

--- a/src/Data/LLVM/BitCode/IR/Values.hs
+++ b/src/Data/LLVM/BitCode/IR/Values.hs
@@ -2,7 +2,7 @@
 
 module Data.LLVM.BitCode.IR.Values (
     getValueTypePair
-  , getConstantFwdRef, getConstantFwdRefAdjustedId
+  , getConstantFwdRefAdjustedId
   , getValue
   , getFnValueById, getFnValueById'
   , parseValueSymbolTableBlock
@@ -18,11 +18,6 @@ import Control.Monad ((<=<),foldM)
 
 
 -- Value Table -----------------------------------------------------------------
-
--- | Return a forward reference if the value is not in the incremental table.
-getConstantFwdRef :: ValueTable -> Type -> Int -> Parse (Typed PValue)
-getConstantFwdRef t ty n = label "getConstantFwdRef" $
-    adjustId n >>= getConstantFwdRefAdjustedId t ty
 
 getConstantFwdRefAdjustedId :: ValueTable -> Type -> Int -> Parse (Typed PValue)
 getConstantFwdRefAdjustedId t ty n' = label "getConstantFwdRefAdjustedId" $ do


### PR DESCRIPTION
As noted in https://github.com/GaloisInc/llvm-pretty-bc-parser/issues/266#issuecomment-1917189766, the operand IDs in constant expressions use an absolute encoding. This means that parsing constant `icmp` expressions with `getConstantFwdRefAdjustedId` (which assumes a relative encoding) is incorrect. All forms of constant expressions besides constant `icmp` expressions use `forwardRef` (which assumes an absolute encoding) to parse their value operands, so constant `icmp` expressions are the odd one out.

This patch fixes the parsing of constant `icmp` expression operands by (1) removing the `getConstantFwdRefAdjustedId` function, and (2) switching to using `forwardRef`.

Fixes https://github.com/GaloisInc/llvm-pretty-bc-parser/issues/266.