### PR TITLE
`llvm-pretty-bc-parser-0.4.1.0` release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for llvm-pretty-bc-parser
 
-## next (TBA)
+## 0.4.1.0 (January 2024)
 
 * Add preliminary support for LLVM versions up through 16.
 * Require building with `llvm-pretty-0.12.*`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Revision history for llvm-pretty-bc-parser
+
+## next (TBA)
+
+* Add preliminary support for LLVM versions up through 16.
+* Require building with `llvm-pretty-0.12.*`.
+* Add preliminary support for parsing opaque pointers. For now,
+  `llvm-pretty-bc-parser` will still fill in the types of certain instructions
+  with non-opaque pointer types (e.g., the type of memory to store in a `store`
+  instruction), so be wary of this if you are parsing a bitcode file that
+  contains opaque pointers. See also the discussion in
+  https://github.com/GaloisInc/llvm-pretty-bc-parser/issues/262.
+* Improve the runtime performance of the parser.
+* A variety of bugfixes. Some notable fixes include:
+  * Fix a bug in which the parser would fail to parse `DIDerivedType` nodes
+    produced by Apple Clang on macOS.
+  * Fix a bug in which the DWARF address space field of a `DIDerivedType` node
+    was parsed incorrectly.
+  * Fix a bug in which constant `fcmp`/`icmp` expressions would parse their
+    operands incorrectly.

--- a/flake.lock
+++ b/flake.lock
@@ -111,10 +111,10 @@
       "flake": false,
       "locked": {
         "lastModified": 1706635035,
-        "narHash": "sha256-Ho/3OKJgPWkkiF/OYKU3ObdCFUewNmA/EwAYRZLdIh8=",
+        "narHash": "sha256-d6roSOu6FMa/z/Rlio1TO+kJ09vx34gOz0NDhfMrF0o=",
         "owner": "elliottt",
         "repo": "llvm-pretty",
-        "rev": "780e7c01cbd0b85172f11ea8edf0d7bbe6a84967",
+        "rev": "e7b2bf1371e51bbc9e7a35070ae311b5a4b2c387",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -110,11 +110,11 @@
     "llvm-pretty-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1695743075,
-        "narHash": "sha256-RRh26tuRDksdWrPDGyoaBnsoPARWL8qa2PTMFtu7900=",
+        "lastModified": 1706635035,
+        "narHash": "sha256-Ho/3OKJgPWkkiF/OYKU3ObdCFUewNmA/EwAYRZLdIh8=",
         "owner": "elliottt",
         "repo": "llvm-pretty",
-        "rev": "8124fc0265b6ca5fde5812c789f40b2ea54af678",
+        "rev": "780e7c01cbd0b85172f11ea8edf0d7bbe6a84967",
         "type": "github"
       },
       "original": {

--- a/llvm-pretty-bc-parser.cabal
+++ b/llvm-pretty-bc-parser.cabal
@@ -75,7 +75,7 @@ Library
                        bytestring  >= 0.10,
                        containers  >= 0.4,
                        fgl         >= 5.5,
-                       llvm-pretty >= 0.11.0.0.101 && < 0.12,
+                       llvm-pretty >= 0.12 && < 0.13,
                        mtl         >= 2.2.2,
                        pretty      >= 1.0.1,
                        uniplate    >= 1.6,

--- a/llvm-pretty-bc-parser.cabal
+++ b/llvm-pretty-bc-parser.cabal
@@ -18,7 +18,7 @@ Description:
 
 Extra-source-files:  disasm-test/tests/*.ll
 
-extra-doc-files: README.md
+extra-doc-files: CHANGELOG.md, README.md
 
 Flag fuzz
   Description:         Enable fuzzing harness

--- a/llvm-pretty-bc-parser.cabal
+++ b/llvm-pretty-bc-parser.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 Name:                llvm-pretty-bc-parser
-Version:             0.4.0.0.99
+Version:             0.4.1.0
 License:             BSD-3-Clause
 License-file:        LICENSE
 Author:              Trevor Elliott <trevor@galois.com>

--- a/llvm-pretty-bc-parser.cabal
+++ b/llvm-pretty-bc-parser.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 Name:                llvm-pretty-bc-parser
-Version:             0.4.1.0
+Version:             0.4.1.0.99
 License:             BSD-3-Clause
 License-file:        LICENSE
 Author:              Trevor Elliott <trevor@galois.com>
@@ -75,7 +75,7 @@ Library
                        bytestring  >= 0.10,
                        containers  >= 0.4,
                        fgl         >= 5.5,
-                       llvm-pretty >= 0.12 && < 0.13,
+                       llvm-pretty >= 0.12.0.0.99 && < 0.13,
                        mtl         >= 2.2.2,
                        pretty      >= 1.0.1,
                        uniplate    >= 1.6,


### PR DESCRIPTION
This is preparation for a Hackage release of `llvm-pretty-bc-parser-0.4.1.0`, which I will cut after this PR lands.