### PR TITLE
Parse atomic operations introduced in LLVM 9+

### DIFF
--- a/disasm-test/Main.hs
+++ b/disasm-test/Main.hs
@@ -372,10 +372,12 @@ assemblyCube llvmver = TS.mkCUBE
   , TS.rootName = "*.ll"
   , TS.separators = "."
   , TS.validParams = [ ("llvm-range", Just [ "recent-llvm"
+                                           , "pre-llvm9"
                                            , "pre-llvm12"
                                            , "pre-llvm13"
                                            , "pre-llvm14"
                                            , "pre-llvm15"
+                                           , "pre-llvm16"
                                            ])
                      ]
     -- Somewhat unusually for tasty-sugar, we make the expectedSuffix the same

--- a/disasm-test/tests/atomicrmw-faddsub.ll
+++ b/disasm-test/tests/atomicrmw-faddsub.ll
@@ -1,0 +1,5 @@
+define void @atomicrmw(float* %a, float %f) {
+    %b11 = atomicrmw fadd float* %a, float %f acquire
+    %b12 = atomicrmw fsub float* %a, float %f acquire
+    ret void
+}

--- a/disasm-test/tests/atomicrmw-faddsub.pre-llvm9.ll
+++ b/disasm-test/tests/atomicrmw-faddsub.pre-llvm9.ll
@@ -1,0 +1,4 @@
+SKIP_TEST
+
+This test case requires the use of atomic `fadd` and `fsub` operations, which
+are only available in LLVM 9 or later.

--- a/disasm-test/tests/atomicrmw-fmaxmin.ll
+++ b/disasm-test/tests/atomicrmw-fmaxmin.ll
@@ -1,0 +1,5 @@
+define void @atomicrmw(float* %a, float %f) {
+    %b13 = atomicrmw fmax float* %a, float %f acquire
+    %b14 = atomicrmw fmin float* %a, float %f acquire
+    ret void
+}

--- a/disasm-test/tests/atomicrmw-fmaxmin.pre-llvm15.ll
+++ b/disasm-test/tests/atomicrmw-fmaxmin.pre-llvm15.ll
@@ -1,0 +1,4 @@
+SKIP_TEST
+
+This test case requires the use of atomic `fmax` and `fmin` operations, which
+are only available in LLVM 15 or later.

--- a/disasm-test/tests/atomicrmw-uincdecwrap.ll
+++ b/disasm-test/tests/atomicrmw-uincdecwrap.ll
@@ -1,0 +1,5 @@
+define void @atomicrmw(i32* %a, i32 %i) {
+    %b15 = atomicrmw uinc_wrap i32* %a, i32 %i acquire
+    %b16 = atomicrmw udec_wrap i32* %a, i32 %i acquire
+    ret void
+}

--- a/disasm-test/tests/atomicrmw-uincdecwrap.pre-llvm16.ll
+++ b/disasm-test/tests/atomicrmw-uincdecwrap.pre-llvm16.ll
@@ -1,0 +1,4 @@
+SKIP_TEST
+
+This test case requires the use of atomic `uinc_wrap` and `udec_wrap`
+operations, which are only available in LLVM 16 or later.

--- a/disasm-test/tests/atomicrmw.ll
+++ b/disasm-test/tests/atomicrmw.ll
@@ -1,4 +1,14 @@
 define void @atomicrmw(i32* %a, i32 %i) {
-    %b = atomicrmw add i32* %a, i32 %i acquire
+    %b0  = atomicrmw xchg i32* %a, i32 %i acquire
+    %b1  = atomicrmw add  i32* %a, i32 %i acquire
+    %b2  = atomicrmw sub  i32* %a, i32 %i acquire
+    %b3  = atomicrmw and  i32* %a, i32 %i acquire
+    %b4  = atomicrmw nand i32* %a, i32 %i acquire
+    %b5  = atomicrmw or   i32* %a, i32 %i acquire
+    %b6  = atomicrmw xor  i32* %a, i32 %i acquire
+    %b7  = atomicrmw max  i32* %a, i32 %i acquire
+    %b8  = atomicrmw min  i32* %a, i32 %i acquire
+    %b9  = atomicrmw umax i32* %a, i32 %i acquire
+    %b10 = atomicrmw umin i32* %a, i32 %i acquire
     ret void
 }

--- a/disasm-test/tests/opaque-atomicrmw-uincdecwrap.ll
+++ b/disasm-test/tests/opaque-atomicrmw-uincdecwrap.ll
@@ -1,0 +1,5 @@
+define void @atomicrmw(ptr %a, i32 %i) {
+    %b15 = atomicrmw uinc_wrap ptr %a, i32 %i acquire
+    %b16 = atomicrmw udec_wrap ptr %a, i32 %i acquire
+    ret void
+}

--- a/disasm-test/tests/opaque-atomicrmw-uincdecwrap.pre-llvm16.ll
+++ b/disasm-test/tests/opaque-atomicrmw-uincdecwrap.pre-llvm16.ll
@@ -1,0 +1,4 @@
+SKIP_TEST
+
+This test case requires the use of atomic `uinc_wrap` and `udec_wrap`
+operations, which are only available in LLVM 16 or later.

--- a/disasm-test/tests/opaque-atomicrmw.ll
+++ b/disasm-test/tests/opaque-atomicrmw.ll
@@ -1,4 +1,18 @@
-define void @atomicrmw(ptr %a, i32 %i) {
-    %b = atomicrmw add ptr %a, i32 %i acquire
+define void @atomicrmw(ptr %a1, i32 %i, ptr %a2, float %f) {
+    %b0  = atomicrmw xchg ptr %a1, i32   %i acquire
+    %b1  = atomicrmw add  ptr %a1, i32   %i acquire
+    %b2  = atomicrmw sub  ptr %a1, i32   %i acquire
+    %b3  = atomicrmw and  ptr %a1, i32   %i acquire
+    %b4  = atomicrmw nand ptr %a1, i32   %i acquire
+    %b5  = atomicrmw or   ptr %a1, i32   %i acquire
+    %b6  = atomicrmw xor  ptr %a1, i32   %i acquire
+    %b7  = atomicrmw max  ptr %a1, i32   %i acquire
+    %b8  = atomicrmw min  ptr %a1, i32   %i acquire
+    %b9  = atomicrmw umax ptr %a1, i32   %i acquire
+    %b10 = atomicrmw umin ptr %a1, i32   %i acquire
+    %b11 = atomicrmw fadd ptr %a2, float %f acquire
+    %b12 = atomicrmw fsub ptr %a2, float %f acquire
+    %b13 = atomicrmw fmax ptr %a2, float %f acquire
+    %b14 = atomicrmw fmin ptr %a2, float %f acquire
     ret void
 }

--- a/flake.lock
+++ b/flake.lock
@@ -107,11 +107,11 @@
     "llvm-pretty-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1709056806,
-        "narHash": "sha256-f5f6wmCKqINPL8d/ShWf5K37drhgJGnzb3fruv5gX9U=",
+        "lastModified": 1721908217,
+        "narHash": "sha256-+JUkalniZnzAk2isu0bnysAywO5kPru27aBxWMg7UJU=",
         "owner": "GaloisInc",
         "repo": "llvm-pretty",
-        "rev": "1f6118dfd25930aac09a7030990c57f857544ee7",
+        "rev": "725bd01c4be76538cf9606696b780415d901c040",
         "type": "github"
       },
       "original": {

--- a/src/Data/LLVM/BitCode/IR/Function.hs
+++ b/src/Data/LLVM/BitCode/IR/Function.hs
@@ -1431,7 +1431,7 @@ getDecodedOrdering 6 = return (Just SeqCst)
 getDecodedOrdering i = Assert.unknownEntity "atomic ordering" i
 
 
--- https://github.com/llvm-mirror/llvm/blob/release_60/include/llvm/Bitcode/LLVMBitCodes.h#L377
+-- https://github.com/llvm/llvm-project/blob/e24dc34aa085b9e8d3ea58cc5f59f80bc4c7cdb4/llvm/include/llvm/Bitcode/LLVMBitCodes.h#L468-L489
 getDecodedAtomicRWOp :: Integer -> Parse AtomicRWOp
 getDecodedAtomicRWOp 0  = pure AtomicXchg
 getDecodedAtomicRWOp 1  = pure AtomicAdd
@@ -1444,6 +1444,12 @@ getDecodedAtomicRWOp 7  = pure AtomicMax
 getDecodedAtomicRWOp 8  = pure AtomicMin
 getDecodedAtomicRWOp 9  = pure AtomicUMax
 getDecodedAtomicRWOp 10 = pure AtomicUMin
+getDecodedAtomicRWOp 11 = pure AtomicFAdd
+getDecodedAtomicRWOp 12 = pure AtomicFSub
+getDecodedAtomicRWOp 13 = pure AtomicFMax
+getDecodedAtomicRWOp 14 = pure AtomicFMin
+getDecodedAtomicRWOp 15 = pure AtomicUIncWrap
+getDecodedAtomicRWOp 16 = pure AtomicUDecWrap
 getDecodedAtomicRWOp v  = Assert.unknownEntity "atomic RWOp" v
 
 {-


### PR DESCRIPTION
This adapts `llvm-pretty-bc-parser` to new atomic operations introduced in LLVM 9 and later:

* This bumps the `llvm-pretty` submodule to incorporate the changes from https://github.com/GaloisInc/llvm-pretty/pull/138 and https://github.com/GaloisInc/llvm-pretty/pull/140.
* This updates the parsing code in `Data.LLVM.BitCode.IR.Function` to account for atomic `fadd`, `fsub`, `fmax`, `fmin`, `uinc_wrap`, and `udec_wrap` operations.
* This ensures that all atomic operations have a corresponding `disasm-test` test case.