### PR TITLE
Add support for LLVM address spaces

### DIFF
--- a/src/Data/LLVM/BitCode/IR/Attrs.hs
+++ b/src/Data/LLVM/BitCode/IR/Attrs.hs
@@ -46,6 +46,18 @@ visibility = choose <=< numeric
     2 -> return ProtectedVisibility
     _ -> mzero
 
+threadLocal :: Match Field ThreadLocality
+threadLocal = choose <=< numeric
+  where
+  choose :: Match Int ThreadLocality
+  choose n = case n of
+    0 -> return NotThreadLocal
+    1 -> return ThreadLocal
+    2 -> return LocalDynamic
+    3 -> return InitialExec
+    4 -> return LocalExec
+    _ -> mzero
+
 unnamedAddr :: Match Field (Maybe UnnamedAddr)
 unnamedAddr = choose <=< numeric
   where

--- a/src/Data/LLVM/BitCode/IR/Attrs.hs
+++ b/src/Data/LLVM/BitCode/IR/Attrs.hs
@@ -45,3 +45,13 @@ visibility = choose <=< numeric
     1 -> return HiddenVisibility
     2 -> return ProtectedVisibility
     _ -> mzero
+
+unnamedAddr :: Match Field (Maybe UnnamedAddr)
+unnamedAddr = choose <=< numeric
+  where
+  choose :: Match Int (Maybe UnnamedAddr)
+  choose n = case n of
+    0 -> return Nothing
+    1 -> return $ Just GlobalUnnamedAddr
+    2 -> return $ Just LocalUnnamedAddr
+    _ -> mzero

--- a/src/Data/LLVM/BitCode/IR/Constants.hs
+++ b/src/Data/LLVM/BitCode/IR/Constants.hs
@@ -540,9 +540,11 @@ parseInlineAsm code getTy r = do
   let field = parseField r
 
   -- If using InlineAsmCode30 or later, we parse the type as an explicit
-  -- field.
+  -- field. We use the default function address space, all inline asm is
+  -- cast to a function type.
   let parseTy  = do ty <- getType =<< field 0 numeric
-                    return (PtrTo ty, 1)
+                    addrSpace <- getDefaultFunctionAddrSpace
+                    return (PtrTo addrSpace ty, 1)
   -- If using an older InlineAsmCode, then we retrieve the type from the
   -- current context.
   let useCurTy = do ty <- getTy

--- a/src/Data/LLVM/BitCode/IR/Constants.hs
+++ b/src/Data/LLVM/BitCode/IR/Constants.hs
@@ -225,7 +225,7 @@ parseConstantEntry t (getTy,cs) (fromEntry -> Just r) =
   4 -> label "CST_CODE_INTEGER" $ do
     let field = parseField r
     ty <- getTy
-    n  <- field 0 signedWord64
+    n  <- field 0 signedInt64
     let val = fromMaybe (ValInteger (toInteger n)) $ do
                 Integer 0 <- elimPrimType ty
                 return (ValBool (n /= 0))

--- a/src/Data/LLVM/BitCode/IR/Function.hs
+++ b/src/Data/LLVM/BitCode/IR/Function.hs
@@ -83,7 +83,7 @@ parseAlias r = do
   (name, offset) <- oldOrStrtabName n r
   let field i = parseField r (i + offset)
   ty       <- getType =<< field 0 numeric
-  _addrSp  <-             field 1 unsigned
+  addrSp <- AddrSpace <$> field 1 numeric
   tgt      <-             field 2 numeric
   lnk      <-             field 3 linkage
   vis      <-             field 4 visibility
@@ -91,7 +91,7 @@ parseAlias r = do
 
   -- XXX: is it the case that the alias type will always be a pointer to the
   -- aliasee?
-  _   <- pushValue (Typed (PtrTo ty) (ValSymbol name))
+  _   <- pushValue (Typed (PtrTo addrSp ty) (ValSymbol name))
 
   return PartialAlias
     { paLinkage    = Just lnk
@@ -122,15 +122,18 @@ type DeclareList = Seq.Seq FunProto
 -- | Turn a function prototype into a declaration.
 finalizeDeclare :: FunProto -> Parse Declare
 finalizeDeclare fp = case protoType fp of
-  PtrTo (FunTy ret args va) -> return Declare
+  PtrTo adr (FunTy ret args va) -> return Declare
     { decLinkage    = protoLinkage fp
     , decVisibility = protoVisibility fp
+    , decUnnamedAddr = protoUnnamedAddr fp
     , decRetType    = ret
     , decName       = protoSym fp
     , decArgs       = args
     , decVarArgs    = va
     , decAttrs      = []
     , decComdat     = protoComdat fp
+    -- TODO what if this isn't equal to adr?
+    , decAddrSpace  = protoAddrSpace fp
     }
   _ -> fail "invalid type on function prototype"
 
@@ -144,6 +147,7 @@ type DefineList = Seq.Seq PartialDefine
 data PartialDefine = PartialDefine
   { partialLinkage    :: Maybe Linkage
   , partialVisibility :: Maybe Visibility
+  , partialAddrSpace  :: AddrSpace
   , partialGC         :: Maybe GC
   , partialSection    :: Maybe String
   , partialRetType    :: Type
@@ -171,6 +175,7 @@ emptyPartialDefine proto = do
   return PartialDefine
     { partialLinkage    = protoLinkage proto
     , partialVisibility = protoVisibility proto
+    , partialAddrSpace  = protoAddrSpace proto
     , partialGC         = protoGC proto
     , partialSection    = protoSect proto
     , partialRetType    = rty
@@ -246,6 +251,7 @@ finalizePartialDefine lkp pd =
     return Define
       { defLinkage    = partialLinkage pd
       , defVisibility = partialVisibility pd
+      , defAddrSpace  = partialAddrSpace pd
       , defGC         = partialGC pd
       , defAttrs      = []
       , defRetType    = partialRetType pd
@@ -599,6 +605,7 @@ parseFunctionBlockEntry _ t d (fromEntry -> Just r) = case recordCode r of
     ty     <- getType           =<< field 1 numeric -- size type
     size   <- getFnValueById ty =<< field 2 numeric -- size value
     align  <-                       field 3 numeric -- alignment value
+    as <- getDefaultAllocaAddrSpace
 
     let sval = case typedValue size of
           ValInteger i | i == 1 -> Nothing
@@ -609,13 +616,13 @@ parseFunctionBlockEntry _ t d (fromEntry -> Just r) = case recordCode r of
                (1 `shiftL` 7)     -- swift error
         aval = (1 `shiftL` (fromIntegral (align .&. complement mask))) `shiftR` 1
         explicitType = testBit align 6
-        ity = if explicitType then PtrTo instty else instty
+        ity = if explicitType then PtrTo as instty else instty
 
     ret <- if explicitType
            then return instty
            else Assert.elimPtrTo "In return type:" instty
 
-    result ity (Alloca ret sval (Just aval)) d
+    result ity (Alloca ret as sval (Just aval)) d
 
   -- [opty,op,align,vol]
   20 -> label "FUNC_CODE_INST_LOAD" $ do
@@ -1284,7 +1291,7 @@ interpGep :: Type -> Typed PValue -> [Typed PValue] -> Parse Type
 interpGep baseTy ptr vs = check (resolveGep baseTy ptr vs)
   where
   check res = case res of
-    HasType rty -> return (PtrTo rty)
+    HasType rty -> return (PtrTo (ptrAddrSpace ptr) rty)
     Invalid -> fail $ unlines $
       [ "Unable to determine the type of getelementptr"
       , "Base type: " ++ show baseTy

--- a/src/Data/LLVM/BitCode/IR/Globals.hs
+++ b/src/Data/LLVM/BitCode/IR/Globals.hs
@@ -50,6 +50,9 @@ parseGlobalVar n r = label "GLOBALVAR" $ do
   vis <- if length (recordFields r) > (6 + offset) && not (link `elem` [Internal, Private])
                 then field 6 visibility
                 else pure DefaultVisibility
+  tl <- if length (recordFields r) > (7 + offset) -- && not (link `elem` [Internal, Private])
+                then field 7 threadLocal
+                else pure NotThreadLocal
 
   unnamed <-
     if length (recordFields r) > (8 + offset)
@@ -74,6 +77,7 @@ parseGlobalVar n r = label "GLOBALVAR" $ do
       attrs = GlobalAttrs
         { gaLinkage     = Just link
         , gaVisibility  = Just vis
+        , gaThreadLocality = Just tl
         , gaUnnamedAddr = unnamed
         , gaConstant    = isconst
         , gaAddrSpace   = addrspace

--- a/src/Data/LLVM/BitCode/Parse.hs
+++ b/src/Data/LLVM/BitCode/Parse.hs
@@ -111,6 +111,7 @@ data ParseState = ParseState
   , psNextResultId  :: !Int
   , psTypeName      :: Maybe String
   , psNextTypeId    :: !Int
+  , psNextSymbolId  :: !Int
   , psLastLoc       :: Maybe PDebugLoc
   , psKinds         :: !KindTable
   , psModVersion    :: !Int
@@ -130,6 +131,7 @@ emptyParseState  = ParseState
   , psNextResultId  = 0
   , psTypeName      = Nothing
   , psNextTypeId    = 0
+  , psNextSymbolId  = 0
   , psLastLoc       = Nothing
   , psKinds         = emptyKindTable
   , psModVersion    = 0
@@ -142,6 +144,14 @@ nextResultId  = Parse $ do
   ps <- get
   put ps { psNextResultId = psNextResultId ps + 1 }
   return (psNextResultId ps)
+
+-- | The next implicit result id.
+nextSymbolId :: Parse Int
+nextSymbolId  = Parse $ do
+  ps <- get
+  put ps { psNextSymbolId = psNextSymbolId ps + 1 }
+  return (psNextSymbolId ps)
+
 
 type PDebugLoc = DebugLoc' Int
 

--- a/src/Data/LLVM/BitCode/Record.hs
+++ b/src/Data/LLVM/BitCode/Record.hs
@@ -182,5 +182,10 @@ oldOrStrtabName n r = do
           Just st -> do
             offset <- parseField r 0 numeric
             len <- parseField r 1 numeric
-            return (resolveStrtabSymbol st offset len, 2)
+            if len == 0
+            then do
+              n <- show <$> nextSymbolId
+              return (Symbol n, 2)
+            else
+              return (resolveStrtabSymbol st offset len, 2)
           Nothing -> fail "New-style name encountered with no string table."

--- a/unit-test/Tests/FuncDataInstances.hs
+++ b/unit-test/Tests/FuncDataInstances.hs
@@ -17,6 +17,7 @@ instance Arbitrary Global where arbitrary = genericArbitrary uniform
 instance Arbitrary GlobalAttrs where arbitrary = genericArbitrary uniform
 instance Arbitrary Linkage where arbitrary = genericArbitrary uniform
 instance Arbitrary Visibility where arbitrary = genericArbitrary uniform
+instance Arbitrary ThreadLocality where arbitrary = genericArbitrary uniform
 
 instance Arbitrary FunAttr where arbitrary = genericArbitrary uniform
 instance Arbitrary Define where arbitrary = genericArbitrary uniform

--- a/unit-test/Tests/PrimInstances.hs
+++ b/unit-test/Tests/PrimInstances.hs
@@ -11,3 +11,5 @@ instance Arbitrary FloatType where arbitrary = genericArbitrary uniform
 instance Arbitrary FP80Value where arbitrary = genericArbitrary uniform
 instance Arbitrary Ident  where arbitrary = genericArbitrary uniform
 instance Arbitrary Symbol where arbitrary = genericArbitrary uniform
+instance Arbitrary UnnamedAddr where arbitrary = genericArbitrary uniform
+instance Arbitrary AddrSpace where arbitrary = genericArbitrary uniform


### PR DESCRIPTION
Address spaces default to 0 and are currently mostly used by CHERI for capabilities (address space 200).

The thread_local property is properly read and reported.

Various formatting changes are implemented to more closely match llvm-dis output.