### PR TITLE
Fix file-local symtab lookups

### DIFF
--- a/disasm-test/known_bugs/llvm_dbg_declare_inline
+++ b/disasm-test/known_bugs/llvm_dbg_declare_inline
@@ -2,6 +2,8 @@
 ##> rootMatchName: localstatic.ll
 ##> summary: llvm.dbg.declare should use md refs and not inline
 
+Logged in https://github.com/GaloisInc/llvm-pretty-bc-parser/issues/260
+
 Attempts to inline declare the !DILocalVariable for the file-local static:
 
   call void @llvm.dbg.declare(metadata i32* %2, metadata !DILocalVariable(scope: !DISubprogram(scope: !3, name: "has_local_static", file: !3, line: 5, type: !9, isLocal: false, isDefinition: true, scopeLine: 5, virtuality: 0, virtualIndex: 0, flags: 256, isOptimized: false, unit: !2, retainedNodes: !4), name: "x", file: !DIFile(filename: "localstatic.c", directory: "/home/kquick/work/DFAMS/tp241209/sources/llvm-pretty-bc-parser/disasm-test/tests"), line: 5, type: !DIBasicType(tag: 36, name: "int", size: 32, align: 0, encoding: 5, flags: 0), arg: 1, flags: 0, align: 0), metadata !DIExpression()), !dbg !DILocation(line: 5, column: 26, scope: !0)

--- a/disasm-test/known_bugs/llvm_dbg_declare_inline
+++ b/disasm-test/known_bugs/llvm_dbg_declare_inline
@@ -1,0 +1,30 @@
+##> rootMatchName: localstatic.c
+##> rootMatchName: localstatic.ll
+##> summary: llvm.dbg.declare should use md refs and not inline
+
+Attempts to inline declare the !DILocalVariable for the file-local static:
+
+  call void @llvm.dbg.declare(metadata i32* %2, metadata !DILocalVariable(scope: !DISubprogram(scope: !3, name: "has_local_static", file: !3, line: 5, type: !9, isLocal: false, isDefinition: true, scopeLine: 5, virtuality: 0, virtualIndex: 0, flags: 256, isOptimized: false, unit: !2, retainedNodes: !4), name: "x", file: !DIFile(filename: "localstatic.c", directory: "/home/kquick/work/DFAMS/tp241209/sources/llvm-pretty-bc-parser/disasm-test/tests"), line: 5, type: !DIBasicType(tag: 36, name: "int", size: 32, align: 0, encoding: 5, flags: 0), arg: 1, flags: 0, align: 0), metadata !DIExpression()), !dbg !DILocation(line: 5, column: 26, scope: !0)
+
+, but llvm-as rejects that:
+
+  llvm-as: file.ll:L:C: error: missing 'distinct', required for !DISubprogram that is a Definition
+
+Adding 'distinct' in various places on the line does not work
+
+The llvm-dis handles this as:
+
+  call void @llvm.dbg.declare(metadata i32* %2, metadata !21, metadata !DIExpression()), !dbg !22
+
+where:
+
+!2 = distinct !DISubprogram(name: "has_local_static", scope: !3, file: !3, line: 5, type: !4, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !7, retainedNodes: !8)
+!21 = !DILocalVariable(name: "x", arg: 1, scope: !2, file: !3, line: 5, type: !6)
+
+Note that for the llvm-disasm version, we do have:
+
+!0 = distinct !DISubprogram(scope: !3, name: "has_local_static", file: !3, line: 5, type: !9, isLocal: false, isDefinition: true, scopeLine: 5, virtuality: 0, virtualIndex: 0, flags: 256, isOptimized: false, unit: !2, retainedNodes: !4)
+!21 = !DILocalVariable(scope: !0, name: "x", file: !3, line: 5, type: !7, arg: 1, flags: 0, align: 0)
+
+So apparently it is mostly needed to have the llvm.dbg.declare use the UnnamedMd
+indices (if available) rather than inlining them.

--- a/disasm-test/tests/localstatic.c
+++ b/disasm-test/tests/localstatic.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+
+#define NUM 3
+
+int has_local_static(int x) {
+    int y;
+    static const void *const disptab[NUM] = { &&fn1, &&fn2, &&fn3 };
+    y = x;
+start:
+    goto *disptab[y];
+fn1:
+    y += 1;
+    goto *disptab[y];
+fn2:
+    y *= 3;
+    goto start;
+fn3:
+    return y;
+}
+
+int main(int argc, char** argv) {
+    printf("= %d\n", has_local_static(argc));
+}

--- a/disasm-test/tests/localstatic.ll
+++ b/disasm-test/tests/localstatic.ll
@@ -1,0 +1,146 @@
+; ModuleID = 'localstatic.bc'
+source_filename = "localstatic.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+@has_local_static.disptab = internal constant [3 x i8*] [i8* blockaddress(@has_local_static, %10), i8* blockaddress(@has_local_static, %17), i8* blockaddress(@has_local_static, %20)], align 16, !dbg !0
+@.str = private unnamed_addr constant [6 x i8] c"= %d\0A\00", align 1
+
+; Function Attrs: noinline nounwind optnone sspstrong uwtable
+define i32 @has_local_static(i32 %0) #0 !dbg !2 {
+  %2 = alloca i32, align 4
+  %3 = alloca i32, align 4
+  store i32 %0, i32* %2, align 4
+  call void @llvm.dbg.declare(metadata i32* %2, metadata !21, metadata !DIExpression()), !dbg !22
+  call void @llvm.dbg.declare(metadata i32* %3, metadata !23, metadata !DIExpression()), !dbg !24
+  %4 = load i32, i32* %2, align 4, !dbg !25
+  store i32 %4, i32* %3, align 4, !dbg !26
+  br label %5, !dbg !27
+
+5:                                                ; preds = %17, %1
+  call void @llvm.dbg.label(metadata !28), !dbg !29
+  %6 = load i32, i32* %3, align 4, !dbg !30
+  %7 = sext i32 %6 to i64, !dbg !31
+  %8 = getelementptr [3 x i8*], [3 x i8*]* @has_local_static.disptab, i64 0, i64 %7, !dbg !31
+  %9 = load i8*, i8** %8, align 8, !dbg !31
+  br label %22, !dbg !32
+
+10:                                               ; preds = %22
+  call void @llvm.dbg.label(metadata !33), !dbg !34
+  %11 = load i32, i32* %3, align 4, !dbg !35
+  %12 = add i32 %11, 1, !dbg !35
+  store i32 %12, i32* %3, align 4, !dbg !35
+  %13 = load i32, i32* %3, align 4, !dbg !36
+  %14 = sext i32 %13 to i64, !dbg !37
+  %15 = getelementptr [3 x i8*], [3 x i8*]* @has_local_static.disptab, i64 0, i64 %14, !dbg !37
+  %16 = load i8*, i8** %15, align 8, !dbg !37
+  br label %22, !dbg !38
+
+17:                                               ; preds = %22
+  call void @llvm.dbg.label(metadata !39), !dbg !40
+  %18 = load i32, i32* %3, align 4, !dbg !41
+  %19 = mul i32 %18, 3, !dbg !41
+  store i32 %19, i32* %3, align 4, !dbg !41
+  br label %5, !dbg !42
+
+20:                                               ; preds = %22
+  call void @llvm.dbg.label(metadata !43), !dbg !44
+  %21 = load i32, i32* %3, align 4, !dbg !45
+  ret i32 %21, !dbg !46
+
+22:                                               ; preds = %10, %5
+  %23 = phi i8* [ %9, %5 ], [ %16, %10 ]
+  indirectbr i8* %23, [label %10, label %17, label %20]
+}
+
+; Function Attrs: nounwind readnone speculatable willreturn
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
+
+; Function Attrs: nounwind readnone speculatable willreturn
+declare void @llvm.dbg.label(metadata) #1
+
+; Function Attrs: noinline nounwind optnone sspstrong uwtable
+define i32 @main(i32 %0, i8** %1) #0 !dbg !47 {
+  %3 = alloca i32, align 4
+  %4 = alloca i8**, align 8
+  store i32 %0, i32* %3, align 4
+  call void @llvm.dbg.declare(metadata i32* %3, metadata !53, metadata !DIExpression()), !dbg !54
+  store i8** %1, i8*** %4, align 8
+  call void @llvm.dbg.declare(metadata i8*** %4, metadata !55, metadata !DIExpression()), !dbg !56
+  %5 = load i32, i32* %3, align 4, !dbg !57
+  %6 = call i32 @has_local_static(i32 %5), !dbg !58
+  %7 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @.str, i64 0, i64 0), i32 %6), !dbg !59
+  ret i32 0, !dbg !60
+}
+
+declare i32 @printf(i8*, ...) #2
+
+attributes #0 = { noinline nounwind optnone sspstrong uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="4" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { nounwind readnone speculatable willreturn }
+attributes #2 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="4" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!llvm.dbg.cu = !{!7}
+!llvm.module.flags = !{!16, !17, !18, !19}
+!llvm.ident = !{!20}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "disptab", scope: !2, file: !3, line: 7, type: !10, isLocal: true, isDefinition: true)
+!2 = distinct !DISubprogram(name: "has_local_static", scope: !3, file: !3, line: 5, type: !4, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !7, retainedNodes: !8)
+!3 = !DIFile(filename: "localstatic.c", directory: "/home/kquick/work/DFAMS/tp241209/sources/llvm-pretty-bc-parser/disasm-test/tests")
+!4 = !DISubroutineType(types: !5)
+!5 = !{!6, !6}
+!6 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!7 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 11.1.0", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !8, globals: !9, splitDebugInlining: false, nameTableKind: None)
+!8 = !{}
+!9 = !{!0}
+!10 = !DICompositeType(tag: DW_TAG_array_type, baseType: !11, size: 192, elements: !14)
+!11 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !12)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DIDerivedType(tag: DW_TAG_const_type, baseType: null)
+!14 = !{!15}
+!15 = !DISubrange(count: 3)
+!16 = !{i32 7, !"Dwarf Version", i32 4}
+!17 = !{i32 2, !"Debug Info Version", i32 3}
+!18 = !{i32 1, !"wchar_size", i32 4}
+!19 = !{i32 7, !"PIC Level", i32 2}
+!20 = !{!"clang version 11.1.0"}
+!21 = !DILocalVariable(name: "x", arg: 1, scope: !2, file: !3, line: 5, type: !6)
+!22 = !DILocation(line: 5, column: 26, scope: !2)
+!23 = !DILocalVariable(name: "y", scope: !2, file: !3, line: 6, type: !6)
+!24 = !DILocation(line: 6, column: 9, scope: !2)
+!25 = !DILocation(line: 8, column: 9, scope: !2)
+!26 = !DILocation(line: 8, column: 7, scope: !2)
+!27 = !DILocation(line: 8, column: 5, scope: !2)
+!28 = !DILabel(scope: !2, name: "start", file: !3, line: 9)
+!29 = !DILocation(line: 9, column: 1, scope: !2)
+!30 = !DILocation(line: 10, column: 19, scope: !2)
+!31 = !DILocation(line: 10, column: 11, scope: !2)
+!32 = !DILocation(line: 10, column: 5, scope: !2)
+!33 = !DILabel(scope: !2, name: "fn1", file: !3, line: 11)
+!34 = !DILocation(line: 11, column: 1, scope: !2)
+!35 = !DILocation(line: 12, column: 7, scope: !2)
+!36 = !DILocation(line: 13, column: 19, scope: !2)
+!37 = !DILocation(line: 13, column: 11, scope: !2)
+!38 = !DILocation(line: 13, column: 5, scope: !2)
+!39 = !DILabel(scope: !2, name: "fn2", file: !3, line: 14)
+!40 = !DILocation(line: 14, column: 1, scope: !2)
+!41 = !DILocation(line: 15, column: 7, scope: !2)
+!42 = !DILocation(line: 16, column: 5, scope: !2)
+!43 = !DILabel(scope: !2, name: "fn3", file: !3, line: 17)
+!44 = !DILocation(line: 17, column: 1, scope: !2)
+!45 = !DILocation(line: 18, column: 12, scope: !2)
+!46 = !DILocation(line: 18, column: 5, scope: !2)
+!47 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 21, type: !48, scopeLine: 21, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !7, retainedNodes: !8)
+!48 = !DISubroutineType(types: !49)
+!49 = !{!6, !6, !50}
+!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !52, size: 64)
+!52 = !DIBasicType(name: "char", size: 8, encoding: DW_ATE_signed_char)
+!53 = !DILocalVariable(name: "argc", arg: 1, scope: !47, file: !3, line: 21, type: !6)
+!54 = !DILocation(line: 21, column: 14, scope: !47)
+!55 = !DILocalVariable(name: "argv", arg: 2, scope: !47, file: !3, line: 21, type: !50)
+!56 = !DILocation(line: 21, column: 27, scope: !47)
+!57 = !DILocation(line: 22, column: 39, scope: !47)
+!58 = !DILocation(line: 22, column: 22, scope: !47)
+!59 = !DILocation(line: 22, column: 5, scope: !47)
+!60 = !DILocation(line: 23, column: 1, scope: !47)

--- a/src/Data/LLVM/BitCode/IR/Function.hs
+++ b/src/Data/LLVM/BitCode/IR/Function.hs
@@ -101,11 +101,11 @@ parseAlias r = do
     , paTarget     = tgt
     }
 
-finalizePartialAlias :: PartialAlias -> Parse GlobalAlias
-finalizePartialAlias pa = label "finalizePartialAlias" $ do
+finalizePartialAlias :: PartialAlias -> Finalize GlobalAlias
+finalizePartialAlias pa = do
   -- aliases refer to absolute offsets
   tv  <- getFnValueById (paType pa) (fromIntegral (paTarget pa))
-  tgt <- liftFinalize $ relabel (const requireBbEntryName) (typedValue tv)
+  tgt <- relabel (const requireBbEntryName) (typedValue tv)
   return GlobalAlias
     { aliasLinkage    = paLinkage pa
     , aliasVisibility = paVisibility pa
@@ -120,7 +120,7 @@ finalizePartialAlias pa = label "finalizePartialAlias" $ do
 type DeclareList = Seq.Seq FunProto
 
 -- | Turn a function prototype into a declaration.
-finalizeDeclare :: FunProto -> Parse Declare
+finalizeDeclare :: FunProto -> Finalize Declare
 finalizeDeclare fp = case protoType fp of
   PtrTo (FunTy ret args va) -> return Declare
     { decLinkage    = protoLinkage fp

--- a/src/Data/LLVM/BitCode/IR/Globals.hs
+++ b/src/Data/LLVM/BitCode/IR/Globals.hs
@@ -82,11 +82,11 @@ finalizeGlobal pg = case pgValueIx pg of
   Nothing -> mkGlobal Nothing
   Just ix -> do
     tv <- getFnValueById (pgType pg) (fromIntegral ix)
-    val <- relabel (const requireBbEntryName) (typedValue tv)
+    val <- relabel requireBbEntryName (typedValue tv)
     mkGlobal (Just val)
   where
   mkGlobal mval =
-    do md <- mapM (relabel (const requireBbEntryName)) (pgMd pg)
+    do md <- mapM (relabel requireBbEntryName) (pgMd pg)
        return Global { globalSym   = pgSym pg
                      , globalAttrs = pgAttrs pg
                      , globalType  = pgType pg

--- a/src/Data/LLVM/BitCode/IR/Globals.hs
+++ b/src/Data/LLVM/BitCode/IR/Globals.hs
@@ -77,13 +77,13 @@ parseGlobalVar n r = label "GLOBALVAR" $ do
     , pgMd      = Map.empty
     }
 
-finalizeGlobal :: PartialGlobal -> Parse Global
+finalizeGlobal :: PartialGlobal -> Finalize Global
 finalizeGlobal pg = case pgValueIx pg of
-  Nothing -> liftFinalize $ mkGlobal Nothing
+  Nothing -> mkGlobal Nothing
   Just ix -> do
     tv <- getFnValueById (pgType pg) (fromIntegral ix)
-    val <- liftFinalize $ relabel (const requireBbEntryName) (typedValue tv)
-    liftFinalize $ mkGlobal (Just val)
+    val <- relabel (const requireBbEntryName) (typedValue tv)
+    mkGlobal (Just val)
   where
   mkGlobal mval =
     do md <- mapM (relabel (const requireBbEntryName)) (pgMd pg)

--- a/src/Data/LLVM/BitCode/IR/Metadata.hs
+++ b/src/Data/LLVM/BitCode/IR/Metadata.hs
@@ -328,7 +328,7 @@ finalizePartialUnnamedMd pum = mkUnnamedMd `fmap` finalizePValMd (pumValues pum)
     }
 
 finalizePValMd :: PValMd -> Finalize ValMd
-finalizePValMd = relabel (const requireBbEntryName)
+finalizePValMd = relabel requireBbEntryName
 
 -- | Partition unnamed entries into global and function local unnamed entries.
 unnamedEntries :: PartialMetadata -> (Seq PartialUnnamedMd, Seq PartialUnnamedMd)

--- a/src/Data/LLVM/BitCode/IR/Module.hs
+++ b/src/Data/LLVM/BitCode/IR/Module.hs
@@ -70,27 +70,28 @@ emptyPartialModule  = PartialModule
 -- module.
 finalizeModule :: PartialModule -> Parse Module
 finalizeModule pm = label "finalizeModule" $ do
-  globals  <- T.mapM finalizeGlobal       (partialGlobals pm)
-  declares <- T.mapM finalizeDeclare      (partialDeclares pm)
-  aliases  <- T.mapM finalizePartialAlias (partialAliases pm)
-  unnamed  <- liftFinalize $ T.mapM finalizePartialUnnamedMd (dedupMetadata (partialUnnamedMd pm))
   types    <- resolveTypeDecls
   let lkp = lookupBlockName (partialDefines pm)
   defines <- T.mapM (finalizePartialDefine lkp) (partialDefines pm)
-  return emptyModule
-    { modSourceName = partialSourceName pm
-    , modTriple     = partialTriple pm
-    , modDataLayout = partialDataLayout pm
-    , modNamedMd    = F.toList (partialNamedMd pm)
-    , modUnnamedMd  = sortOn umIndex (F.toList unnamed)
-    , modGlobals    = F.toList globals
-    , modDefines    = F.toList defines
-    , modTypes      = types
-    , modDeclares   = F.toList declares
-    , modInlineAsm  = partialInlineAsm pm
-    , modAliases    = F.toList aliases
-    , modComdat     = Map.fromList (F.toList (partialComdat pm))
-    }
+  liftFinalize $ do
+    globals  <- T.mapM finalizeGlobal (partialGlobals pm)
+    declares <- T.mapM finalizeDeclare (partialDeclares pm)
+    aliases  <- T.mapM finalizePartialAlias (partialAliases pm)
+    unnamed  <- T.mapM finalizePartialUnnamedMd (dedupMetadata (partialUnnamedMd pm))
+    return emptyModule
+      { modSourceName = partialSourceName pm
+      , modTriple     = partialTriple pm
+      , modDataLayout = partialDataLayout pm
+      , modNamedMd    = F.toList (partialNamedMd pm)
+      , modUnnamedMd  = sortOn umIndex (F.toList unnamed)
+      , modGlobals    = F.toList globals
+      , modDefines    = F.toList defines
+      , modTypes      = types
+      , modDeclares   = F.toList declares
+      , modInlineAsm  = partialInlineAsm pm
+      , modAliases    = F.toList aliases
+      , modComdat     = Map.fromList (F.toList (partialComdat pm))
+      }
 
 -- | Parse an LLVM Module out of the top-level block in a Bitstream.
 parseModuleBlock :: [Entry] -> Parse Module

--- a/src/Data/LLVM/BitCode/IR/Module.hs
+++ b/src/Data/LLVM/BitCode/IR/Module.hs
@@ -71,10 +71,9 @@ emptyPartialModule  = PartialModule
 finalizeModule :: PartialModule -> Parse Module
 finalizeModule pm = label "finalizeModule" $ do
   types    <- resolveTypeDecls
-  let lkp = lookupBlockName (partialDefines pm)
   let defs = Map.fromList [ (partialName d, partialSymtab d)
                           | d <- F.toList (partialDefines pm) ]
-  defines <- T.mapM (finalizePartialDefine lkp defs) (partialDefines pm)
+  defines <- T.mapM (finalizePartialDefine defs) (partialDefines pm)
   liftFinalize defs $ do
     globals  <- T.mapM finalizeGlobal (partialGlobals pm)
     declares <- T.mapM finalizeDeclare (partialDeclares pm)

--- a/src/Data/LLVM/BitCode/IR/Module.hs
+++ b/src/Data/LLVM/BitCode/IR/Module.hs
@@ -72,8 +72,10 @@ finalizeModule :: PartialModule -> Parse Module
 finalizeModule pm = label "finalizeModule" $ do
   types    <- resolveTypeDecls
   let lkp = lookupBlockName (partialDefines pm)
-  defines <- T.mapM (finalizePartialDefine lkp) (partialDefines pm)
-  liftFinalize $ do
+  let defs = Map.fromList [ (partialName d, partialSymtab d)
+                          | d <- F.toList (partialDefines pm) ]
+  defines <- T.mapM (finalizePartialDefine lkp defs) (partialDefines pm)
+  liftFinalize defs $ do
     globals  <- T.mapM finalizeGlobal (partialGlobals pm)
     declares <- T.mapM finalizeDeclare (partialDeclares pm)
     aliases  <- T.mapM finalizePartialAlias (partialAliases pm)

--- a/src/Data/LLVM/BitCode/IR/Values.hs
+++ b/src/Data/LLVM/BitCode/IR/Values.hs
@@ -52,10 +52,7 @@ getValue :: ValueTable -> Type -> Int -> Parse (Typed PValue)
 getValue vt ty n = label "getValue" (getFnValueById' (Just vt) ty =<< adjustId n)
 
 -- | Lookup a value by its absolute id, or perhaps some metadata.
-getFnValueById' :: HasMdTable m
-                => HasParseEnv m
-                => HasValueTable m
-                => MonadFail m
+getFnValueById' :: (HasMdTable m, HasParseEnv m, HasValueTable m, MonadFail m)
                 => Maybe ValueTable -> Type -> Int -> m (Typed PValue)
 getFnValueById' mbVt ty n = case ty of
 

--- a/src/Data/LLVM/BitCode/IR/Values.hs
+++ b/src/Data/LLVM/BitCode/IR/Values.hs
@@ -44,15 +44,20 @@ getValueTypePair t r ix = do
 --getValueNoFwdRef :: Type -> Int -> Parse (Typed PValue)
 --getValueNoFwdRef ty n = label "getValueNoFwdRef" (getFnValueById ty =<< adjustId n)
 
-getFnValueById :: Type -> Int -> Parse (Typed PValue)
+getFnValueById :: (HasMdTable m, HasParseEnv m, HasValueTable m, MonadFail m)
+               => Type -> Int -> m (Typed PValue)
 getFnValueById  = getFnValueById' Nothing
 
 getValue :: ValueTable -> Type -> Int -> Parse (Typed PValue)
 getValue vt ty n = label "getValue" (getFnValueById' (Just vt) ty =<< adjustId n)
 
 -- | Lookup a value by its absolute id, or perhaps some metadata.
-getFnValueById' :: Maybe ValueTable -> Type -> Int -> Parse (Typed PValue)
-getFnValueById' mbVt ty n = label "getFnValueById'" $ case ty of
+getFnValueById' :: HasMdTable m
+                => HasParseEnv m
+                => HasValueTable m
+                => MonadFail m
+                => Maybe ValueTable -> Type -> Int -> m (Typed PValue)
+getFnValueById' mbVt ty n = case ty of
 
   PrimType Metadata -> do
     cxt <- getContext


### PR DESCRIPTION
An LLVM Bitcode file, it is comprised of nested Blocks of information, with
records available at each block.  Different blocks hold different types of
information, and the nesting represents program scope and what is
defined/accessible at a particular point within the program.

The `Parse` and `Finalize` monads maintain a set of symbol tables to use for
lookups, as stored in the `Env` structure referenced by those monads:

  * `valSymtab` for value references

  * `fnSymtab` for function references

  * `bbSymTab` for basic-block references, either "named" by association with
    a symbol name (like the function's entry block) or "anonymous", where
    there is no direct symbol but there may be a block label (like for a goto
    statement or similar surface language construct.)

These lookups are necessary to "relabel" values that reference symbol or label
addresses in the code with the actual targets as resolved by processing the
entirety of the LLVM bitcode file.  The llvm-pretty-bc-parser runs in two
phases: the initial phase where it processes the LLVM bitcode stream to create
"Partial" representations of all of the elements, followed by a "finalization"
phase where it performs all of the label references above (via the llvm-pretty
`relabel` operation), as well as other fixups to convert the "Partial" data
structures into the structures defined by the `llvm-pretty` AST.

However, the tables in the `Env` structure previously only held the direct
symbol tables (i.e. `VALUE_SYMTAB_BLOCK`, found immediately within the
module's top-level `MODULE_BLOCK`.  Symbol resolution was performed by calling
`bbEntryName` or `requireBbEntryName`.  This was sufficient to resolve global
symbol references.

When finalizing functions, the Function finalization defined an alternate
resolution type (`BlockLookup`) and function (`lookupBlockName`) to use with
`relabel` for handling the code within the function.  The `bbEntryName` and
`requireBbEntryName` did not accept a symbol (identifying the function or
`Define` in LLVM IR parlance) so they could only reference the top-level
symbol tables, whereas `lookupBlockName` was used if the `relabel` indicated
there was an associated symbol: it would find the (partial) symbol table for
the function (`Define`) associated with that symbol and perform the `bbSymtab`
lookup from that block.

This duplication of functionality should have been a suggestion that something
was not right, particularly when the `bbEntryName` and `requireBbEntryName`
uses simply discarded any supplied symbol name.  But it worked most of the
time, so this went unnoticed for quite some time (eleven years or so), but it
finally broke when the assumptions about the ability to discard symbol names
was proven to be a bad.

What was it that revealed the invalidity of this assumption?

Answer: Function-local label references.

Consider the following

```
  int has_local_static(int x) {
    static const void *const disptab[NUM] = { &&fn1, &&fn2, &&fn3 };
    int y;
  fn1:
    ...
    goto *disptab[y];
  fn2:
    ...
    goto *disptab[y];
  fn3:
    return y;
  }
```

In this code, `disptab` is a local static.  To implement this, clang adds the
definition of `disptab` to the top-level `VALUE_SYMTAB_BLOCK`.  However, the
values in that list are local references to `has_local_static`.  The `relabel`
operation will supply the `has_local_static` symbol, but VALUE_SYMTAB_BLOCK
finalization (`finalizeGlobal`) uses `requireBbEntryName` and discards that
supplied symbol, thus failing to find the symbol in the top-level symbol block
and halting the parse with `fail`--or even worse, finding an unrelated global
basic-block reference and using that to create invalid references.  Neither of
these is any kind of good.

To fix this, this PR enhances the reader environment for Finalizeto also maintain the `Define` symtabs entries obtained during parsing, and then enhancing `bbEntryName` (and
`requireBbEntryName`) to lookup any symbols and perform `bbSymtab` resolution in the symbol
table associated with that definition.  This means the `relabel`-supplied symbol
names are no longer ignored, and also means that `bbEntryName` is capable of
performing the full resolution that `lookupBlockName` was concocted to handle,
so the latter is removed as obsolete.  These changes allow us to successfully
parse the bitcode for the `has_local_static` function above (also added as a
test in `disasm-test/tests/localstatic.c`).

A test is included; running the `cabal run disasm-test` or simply `cabal run llvm-disasm -- disasm_test/test/localstatic.bc` at the commit where this was introduced shows the error; subsequent commits fix the issue.  Unfortunately, the test still fails round-trip as described in the known_bugs file added; this is for a somewhat separate issue that I would prefer to fix independently.

All commits are atomic; this PR can be split up if desired.