### PR TITLE
Downgrade metadata size-related errors into warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Revision history for llvm-pretty-bc-parser
 
+## next (TBA)
+
+* `Data.LLVM.BitCode` now defines funtions (whose names all end with
+  `*WithWarnings`) that return any parser-related warnings (`ParseWarning`s)
+  alongside the parsed `Module`. Users can decide whether or not to display
+  these warnings (e.g., by printing them to `stderr` using `ppParseWarnings`).
+* The functions in `Data.LLVM.BitCode` no longer produce a fatal error when
+  encountering metadata records of unexpected sizes. Instead, these are now
+  treated as warnings.
+
 ## 0.4.2.0 (August 2024)
 
 * Add support for GHC 9.8 and drop official support of 9.2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   `*WithWarnings`) that return any parser-related warnings (`ParseWarning`s)
   alongside the parsed `Module`. Users can decide whether or not to display
   these warnings (e.g., by printing them to `stderr` using `ppParseWarnings`).
+
+  The existing functions which do not return warnings have been deprecated in
+  favor of the their `*WithWarnings` variants.
 * The functions in `Data.LLVM.BitCode` no longer produce a fatal error when
   encountering metadata records of unexpected sizes. Instead, these are now
   treated as warnings.

--- a/disasm-test/Main.hs
+++ b/disasm-test/Main.hs
@@ -27,6 +27,7 @@ import           Data.Map ( (!), (!?) )
 import qualified Data.Map as Map
 import           Data.Maybe ( fromMaybe )
 import           Data.Proxy ( Proxy(..) )
+import           Data.Sequence ( Seq )
 import           Data.String.Interpolate
 import qualified Data.Text as T
 import           Data.Typeable (Typeable)
@@ -727,7 +728,7 @@ normalizeModule = sorted . everywhere (mkT zeroValMdRef)
 processBitCode :: FilePath -> FilePath -> TestM (FilePath, Maybe FilePath)
 processBitCode pfx file = do
   let handler ::
-        X.SomeException -> IO (Either Error (AST.Module, [ParseWarning]))
+        X.SomeException -> IO (Either Error (AST.Module, Seq ParseWarning))
       handler se = return (Left (Error [] (show se)))
       printToTempFile sufx stuff = do
         tmp        <- getTemporaryDirectory

--- a/src/Data/LLVM/BitCode.hs
+++ b/src/Data/LLVM/BitCode.hs
@@ -27,104 +27,117 @@ import Control.Monad ((<=<))
 import qualified Control.Exception as X
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
-import Data.Foldable (toList)
+import Data.Sequence (Seq)
 
 -- | Parse the contents of an LLVM bitcode file as a strict 'S.ByteString'. If
--- parsing succeeds, return the parsed 'Module' in a 'Right' value. Otherwise,
--- return an 'Error' describing what went wrong in a 'Left' value.
+-- parsing succeeds, return the parsed 'Module'. Otherwise, return an 'Error'
+-- describing what went wrong.
 --
 -- See also 'parseBitCodeWithWarnings' for a version that also returns any
--- warnings that arise during parsing.
+-- warnings that arise during parsing. This function will simply discard all
+-- such warnings, which is why this function is deprecated.
 parseBitCode :: S.ByteString -> IO (Either Error Module)
 parseBitCode =
   fmap (fmap fst) . parseBitstream . parseBitCodeBitstream
+{-# DEPRECATED
+      parseBitCode
+      "Use parseBitCodeWithWarnings instead." #-}
 
 -- | Load an LLVM bitcode file as a strict 'S.ByteString' and parse its
--- contents. If parsing succeeds, return the parsed 'Module' in a 'Right' value.
--- Otherwise, return an 'Error' describing what went wrong in a 'Left' value.
+-- contents. If parsing succeeds, return the parsed 'Module'. Otherwise, return
+-- an 'Error' describing what went wrong.
 --
 -- See also 'parseBitCodeFromFileWithWarnings' for a version that also returns
--- any warnings that arise during parsing.
+-- any warnings that arise during parsing. This function will simply discard all
+-- such warnings, which is why this function is deprecated.
 parseBitCodeFromFile :: FilePath -> IO (Either Error Module)
 parseBitCodeFromFile =
   parseBitCode <=< S.readFile
+{-# DEPRECATED
+      parseBitCodeFromFile
+      "Use parseBitCodeFromFileWithWarnings instead." #-}
 
 -- | Parse the contents of an LLVM bitcode file as a lazy 'L.ByteString'. If
--- parsing succeeds, return the parsed 'Module' in a 'Right' value. Otherwise,
--- return an 'Error' describing what went wrong in a 'Left' value.
+-- parsing succeeds, return the parsed 'Module'. Otherwise, return an 'Error'
+-- describing what went wrong.
 --
 -- See also 'parseBitCodeLazyWithWarnings' for a version that also returns any
--- warnings that arise during parsing.
+-- warnings that arise during parsing. This function will simply discard all
+-- such warnings, which is why this function is deprecated.
 parseBitCodeLazy :: L.ByteString -> IO (Either Error Module)
 parseBitCodeLazy =
   fmap (fmap fst) . parseBitstream . parseBitCodeBitstreamLazy
+{-# DEPRECATED
+      parseBitCodeLazy
+      "Use parseBitCodeLazyWithWarnings instead." #-}
 
 -- | Load an LLVM bitcode file as a lazy 'L.ByteString' and parse its contents.
--- If parsing succeeds, return the parsed 'Module' in a 'Right' value.
--- Otherwise, return an 'Error' describing what went wrong in a 'Left' value.
+-- If parsing succeeds, return the parsed 'Module'. Otherwise, return an 'Error'
+-- describing what went wrong in a 'Left' value.
 --
 -- See also 'parseBitCodeLazyFromFileWithWarnings' for a version that also
--- returns any warnings that arise during parsing.
+-- returns any warnings that arise during parsing. This function will simply
+-- discard all such warnings, which is why this function is deprecated.
 parseBitCodeLazyFromFile :: FilePath -> IO (Either Error Module)
 parseBitCodeLazyFromFile =
   parseBitCodeLazy <=< L.readFile
+{-# DEPRECATED
+      parseBitCodeLazyFromFile
+      "Use parseBitCodeLazyFromFileWithWarnings instead." #-}
 
 -- | Parse the contents of an LLVM bitcode file as a strict 'S.ByteString'. If
 -- parsing succeeds, return the parsed 'Module' and any 'ParseWarning's that
--- were emitted in a 'Right' value. Otherwise, return an 'Error' describing what
--- went wrong in a 'Left' value.
+-- were emitted. Otherwise, return an 'Error' describing what went wrong.
 --
 -- See also 'parseBitCode' for a version that discards any warnings that arise
 -- during parsing.
 parseBitCodeWithWarnings ::
-  S.ByteString -> IO (Either Error (Module, [ParseWarning]))
+  S.ByteString -> IO (Either Error (Module, Seq ParseWarning))
 parseBitCodeWithWarnings =
   parseBitstream . parseBitCodeBitstream
 
 -- | Load an LLVM bitcode file as a strict 'S.ByteString' and parse its
 -- contents. If parsing succeeds, return the parsed 'Module' and any
--- 'ParseWarnings' that were emitted in a 'Right' value. Otherwise, return an
--- 'Error' describing what went wrong in a 'Left' value.
+-- 'ParseWarnings' that were emitted. Otherwise, return an 'Error' describing
+-- what went wrong.
 --
 -- See also 'parseBitCodeFromFile' for a version that discards any warnings that
 -- arise during parsing.
 parseBitCodeFromFileWithWarnings ::
-  FilePath -> IO (Either Error (Module, [ParseWarning]))
+  FilePath -> IO (Either Error (Module, Seq ParseWarning))
 parseBitCodeFromFileWithWarnings =
   parseBitCodeWithWarnings <=< S.readFile
 
 -- | Parse the contents of an LLVM bitcode file as a lazy 'L.ByteString'. If
 -- parsing succeeds, return the parsed 'Module' and any 'ParseWarning's that
--- were emitted in a 'Right' value. Otherwise, return an 'Error' describing what
--- went wrong in a 'Left' value.
+-- were emitted. Otherwise, return an 'Error' describing what went wrong.
 --
 -- See also 'parseBitCodeLazy' for a version that discards any warnings that
 -- arise during parsing.
 parseBitCodeLazyWithWarnings ::
-  L.ByteString -> IO (Either Error (Module, [ParseWarning]))
+  L.ByteString -> IO (Either Error (Module, Seq ParseWarning))
 parseBitCodeLazyWithWarnings =
   parseBitstream . parseBitCodeBitstreamLazy
 
 -- | Load an LLVM bitcode file as a lazy 'L.ByteString' and parse its contents.
 -- If parsing succeeds, return the parsed 'Module' and any 'ParseWarnings' that
--- were emitted in a 'Right' value. Otherwise, return an 'Error' describing what
--- went wrong in a 'Left' value.
+-- were emitted. Otherwise, return an 'Error' describing what went wrong.
 --
 -- See also 'parseBitCodeLazyFromFile' for a version that discards any warnings
 -- that arise during parsing.
 parseBitCodeLazyFromFileWithWarnings ::
-  FilePath -> IO (Either Error (Module, [ParseWarning]))
+  FilePath -> IO (Either Error (Module, Seq ParseWarning))
 parseBitCodeLazyFromFileWithWarnings =
   parseBitCodeLazyWithWarnings <=< L.readFile
 
 parseBitstream ::
-  Either String Bitstream -> IO (Either Error (Module, [ParseWarning]))
+  Either String Bitstream -> IO (Either Error (Module, Seq ParseWarning))
 parseBitstream e = case e of
   Left err   -> mkError ["Bitstream"] err
   Right bits -> do
     res <- X.handle (return . Left . badRefError)
                     (X.evaluate (runParse (parseModule bits)))
-    pure $ fmap (\(m, st) -> (m, toList (psWarnings st))) res
+    pure $ fmap (\(m, st) -> (m, psWarnings st)) res
   where
   mkError cxt msg = return $ Left Error
     { errMessage = msg

--- a/src/Data/LLVM/BitCode.hs
+++ b/src/Data/LLVM/BitCode.hs
@@ -1,40 +1,130 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Data.LLVM.BitCode (
     -- * Bitcode Parsing
+    -- ** Without 'ParseWarning's
     parseBitCode,     parseBitCodeFromFile
   , parseBitCodeLazy, parseBitCodeLazyFromFile
+    -- ** With 'ParseWarning's
+  , parseBitCodeWithWarnings,     parseBitCodeFromFileWithWarnings
+  , parseBitCodeLazyWithWarnings, parseBitCodeLazyFromFileWithWarnings
 
     -- * Re-exported
   , Error(..), formatError
+  , ParseWarning(..), MetadataRecordSizeRange(..)
+  , ppParseWarnings, ppParseWarning
   ) where
 
 import Data.LLVM.BitCode.Bitstream
     (Bitstream,parseBitCodeBitstream,parseBitCodeBitstreamLazy)
 import Data.LLVM.BitCode.IR (parseModule)
-import Data.LLVM.BitCode.Parse (runParse,badRefError,Error(..),formatError)
+import Data.LLVM.BitCode.Parse (runParse,badRefError,Error(..),formatError,
+                                MetadataRecordSizeRange(..),ParseWarning(..),
+                                ParseState(..),ppParseWarning,ppParseWarnings)
 import Text.LLVM.AST (Module)
 
 import Control.Monad ((<=<))
 import qualified Control.Exception as X
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
+import Data.Foldable (toList)
 
+-- | Parse the contents of an LLVM bitcode file as a strict 'S.ByteString'. If
+-- parsing succeeds, return the parsed 'Module' in a 'Right' value. Otherwise,
+-- return an 'Error' describing what went wrong in a 'Left' value.
+--
+-- See also 'parseBitCodeWithWarnings' for a version that also returns any
+-- warnings that arise during parsing.
 parseBitCode :: S.ByteString -> IO (Either Error Module)
-parseBitCode  = parseBitstream . parseBitCodeBitstream
+parseBitCode =
+  fmap (fmap fst) . parseBitstream . parseBitCodeBitstream
 
+-- | Load an LLVM bitcode file as a strict 'S.ByteString' and parse its
+-- contents. If parsing succeeds, return the parsed 'Module' in a 'Right' value.
+-- Otherwise, return an 'Error' describing what went wrong in a 'Left' value.
+--
+-- See also 'parseBitCodeFromFileWithWarnings' for a version that also returns
+-- any warnings that arise during parsing.
 parseBitCodeFromFile :: FilePath -> IO (Either Error Module)
-parseBitCodeFromFile  = parseBitCode <=< S.readFile
+parseBitCodeFromFile =
+  parseBitCode <=< S.readFile
 
+-- | Parse the contents of an LLVM bitcode file as a lazy 'L.ByteString'. If
+-- parsing succeeds, return the parsed 'Module' in a 'Right' value. Otherwise,
+-- return an 'Error' describing what went wrong in a 'Left' value.
+--
+-- See also 'parseBitCodeLazyWithWarnings' for a version that also returns any
+-- warnings that arise during parsing.
 parseBitCodeLazy :: L.ByteString -> IO (Either Error Module)
-parseBitCodeLazy  = parseBitstream . parseBitCodeBitstreamLazy
+parseBitCodeLazy =
+  fmap (fmap fst) . parseBitstream . parseBitCodeBitstreamLazy
 
+-- | Load an LLVM bitcode file as a lazy 'L.ByteString' and parse its contents.
+-- If parsing succeeds, return the parsed 'Module' in a 'Right' value.
+-- Otherwise, return an 'Error' describing what went wrong in a 'Left' value.
+--
+-- See also 'parseBitCodeLazyFromFileWithWarnings' for a version that also
+-- returns any warnings that arise during parsing.
 parseBitCodeLazyFromFile :: FilePath -> IO (Either Error Module)
-parseBitCodeLazyFromFile  = parseBitCodeLazy <=< L.readFile
+parseBitCodeLazyFromFile =
+  parseBitCodeLazy <=< L.readFile
 
-parseBitstream :: Either String Bitstream -> IO (Either Error Module)
+-- | Parse the contents of an LLVM bitcode file as a strict 'S.ByteString'. If
+-- parsing succeeds, return the parsed 'Module' and any 'ParseWarning's that
+-- were emitted in a 'Right' value. Otherwise, return an 'Error' describing what
+-- went wrong in a 'Left' value.
+--
+-- See also 'parseBitCode' for a version that discards any warnings that arise
+-- during parsing.
+parseBitCodeWithWarnings ::
+  S.ByteString -> IO (Either Error (Module, [ParseWarning]))
+parseBitCodeWithWarnings =
+  parseBitstream . parseBitCodeBitstream
+
+-- | Load an LLVM bitcode file as a strict 'S.ByteString' and parse its
+-- contents. If parsing succeeds, return the parsed 'Module' and any
+-- 'ParseWarnings' that were emitted in a 'Right' value. Otherwise, return an
+-- 'Error' describing what went wrong in a 'Left' value.
+--
+-- See also 'parseBitCodeFromFile' for a version that discards any warnings that
+-- arise during parsing.
+parseBitCodeFromFileWithWarnings ::
+  FilePath -> IO (Either Error (Module, [ParseWarning]))
+parseBitCodeFromFileWithWarnings =
+  parseBitCodeWithWarnings <=< S.readFile
+
+-- | Parse the contents of an LLVM bitcode file as a lazy 'L.ByteString'. If
+-- parsing succeeds, return the parsed 'Module' and any 'ParseWarning's that
+-- were emitted in a 'Right' value. Otherwise, return an 'Error' describing what
+-- went wrong in a 'Left' value.
+--
+-- See also 'parseBitCodeLazy' for a version that discards any warnings that
+-- arise during parsing.
+parseBitCodeLazyWithWarnings ::
+  L.ByteString -> IO (Either Error (Module, [ParseWarning]))
+parseBitCodeLazyWithWarnings =
+  parseBitstream . parseBitCodeBitstreamLazy
+
+-- | Load an LLVM bitcode file as a lazy 'L.ByteString' and parse its contents.
+-- If parsing succeeds, return the parsed 'Module' and any 'ParseWarnings' that
+-- were emitted in a 'Right' value. Otherwise, return an 'Error' describing what
+-- went wrong in a 'Left' value.
+--
+-- See also 'parseBitCodeLazyFromFile' for a version that discards any warnings
+-- that arise during parsing.
+parseBitCodeLazyFromFileWithWarnings ::
+  FilePath -> IO (Either Error (Module, [ParseWarning]))
+parseBitCodeLazyFromFileWithWarnings =
+  parseBitCodeLazyWithWarnings <=< L.readFile
+
+parseBitstream ::
+  Either String Bitstream -> IO (Either Error (Module, [ParseWarning]))
 parseBitstream e = case e of
   Left err   -> mkError ["Bitstream"] err
-  Right bits -> X.handle (return . Left . badRefError)
-                         (X.evaluate (runParse (parseModule bits)))
+  Right bits -> do
+    res <- X.handle (return . Left . badRefError)
+                    (X.evaluate (runParse (parseModule bits)))
+    pure $ fmap (\(m, st) -> (m, toList (psWarnings st))) res
   where
   mkError cxt msg = return $ Left Error
     { errMessage = msg

--- a/src/Data/LLVM/BitCode/Parse.hs
+++ b/src/Data/LLVM/BitCode/Parse.hs
@@ -24,6 +24,7 @@ import           Control.Monad.Except (MonadError(..), Except, runExcept)
 import           Control.Monad.Reader (MonadReader(..), ReaderT(..), asks)
 import           Control.Monad.State.Strict (MonadState(..), StateT(..)
                                             , gets, modify)
+import qualified Data.Foldable as F
 import           Data.Maybe (fromMaybe)
 import           Data.Semigroup
 import           Data.Typeable (Typeable)
@@ -845,7 +846,7 @@ ppParseWarning (InvalidMetadataRecordSize len range cxt) =
 
 -- | Pretty-print a group of 'ParseWarning's in a format suitable for
 -- user-facing messages.
-ppParseWarnings :: [ParseWarning] -> PP.Doc
+ppParseWarnings :: Seq.Seq ParseWarning -> PP.Doc
 ppParseWarnings warnings
   | null warnings
   = PP.empty
@@ -855,7 +856,7 @@ ppParseWarnings warnings
       map
         (\warning ->
           PP.nest 4 $ PP.vcat [ppParseWarning warning, ""])
-        warnings ++
+        (F.toList warnings) ++
       [supportMsg | any isInvalidMetadataRecordSize warnings]
   where
     isInvalidMetadataRecordSize :: ParseWarning -> Bool


### PR DESCRIPTION
Previously, `llvm-pretty-bc-parser` would produce a fatal error if it encountered a metadata record with an unexpected size. This proves to be extremely cumbersome in practice, however, as LLVM frequently adds new fields to metadata records, and this causes a fair bit of headaches when attempting to support newer LLVM versions.

This patch downgrades this class of errors into warnings. It does so by:
    
* Introducing a new `ParseWarning` data type that captures all types of parser-related warnings. (For now, the only type of `ParseWarning` is `InvalidMetadataRecordSize`, but we may add more in the future.)
    
* Adding new functions to `Data.LLVM.BitCode` (all of which end with `*WithWarnings`) that return `ParseWarning`s alongside the parsed `Module`. As such, this patch does not change any of the existing `Data.LLVM.BitCode` API. It is up to users to decide if they want to opt into the new API that offers `ParseWarning`s.
    
See the changes in the `disasm-test` and `llvm-disasm` test suite for examples of how to use the new API.

Fixes #248.