### PR TITLE
Use `i1`, not `i0`, in special case for `ValBool` parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
     respectively.
 * Support parsing `icmp` instructions that use the `samesign` flag (introduced
   in LLVM 20), indicating that the arguments must have the same sign.
+* Fix a bug in which `i1 true` literals would be parsed as
+  `i1 18446744073709551615` in certain cases.
 
 ## 0.5.1.0 (October 2025)
 

--- a/src/Data/LLVM/BitCode/IR/Constants.hs
+++ b/src/Data/LLVM/BitCode/IR/Constants.hs
@@ -256,7 +256,11 @@ parseConstantEntry t (getTy,cs) (fromEntry -> Just r) =
     ty <- getTy
     n  <- field 0 signedWord64
     let val = fromMaybe (ValInteger (toInteger n)) $ do
-                Integer 0 <- elimPrimType ty
+                -- Include a special case for `i1`, as we would prefer to
+                -- render values of this type as `false` or `true` instead of
+                -- as integer literals. Note that `false` is always encoded as
+                -- `0`, but `true` may be encoded as `1` or `-1`.
+                Integer 1 <- elimPrimType ty
                 return (ValBool (n /= 0))
     return (getTy, Typed ty val:cs)
 


### PR DESCRIPTION
The boolean literals `false` and `true` have the type `i1`, but the special case for `ValBool`s in the logic for parsing integer constants incorrectly used the type `i0`. As such, `true` would never be parsed as `ValBool True`, and in certain cases, it might even be parsed as `ValInteger (-1)`, as `-1` is one possible encoding of `true` at the bitcode level. This, in turn, would be pretty-printed as `i1 18446744073709551615`, which is very counter-intuitive to users.

Fix this by special-casing `i1` instead. Fixes https://github.com/GaloisInc/llvm-pretty/issues/13.