### PR TITLE
LLVM Metadata parse failures are warnings only

### DIFF
--- a/src/Data/LLVM/BitCode/IR/Metadata.hs
+++ b/src/Data/LLVM/BitCode/IR/Metadata.hs
@@ -455,6 +455,15 @@ parseMetadataEntry vt mt pm (fromEntry -> Just r) =
             (Just . ValMdValue . Typed (PrimType (Integer 64)) . ValInteger)
             (parseField r n numeric)
 
+      mdNotImplemented :: String -> Parse PartialMetadata
+      mdNotImplemented name = do
+        addParseWarning $ UnsupportedMetadataRecordCode (recordCode r) name
+        -- Some sort of placeholder entry must be added to the metadata table,
+        -- because it may be cross-reference by other metadata; here we use an
+        -- empty expression as that placeholder.
+        return $! updateMetadataTable
+          (addDebugInfo False (DebugInfoExpression $ DIExpression mempty)) pm
+
   -- Note: the parsing cases below use a Monadic coding style, as opposed to an
   -- Applicative style (as was originally used) for performance reasons:
   -- Applicative record construction has quadratic size and corresponding
@@ -1193,17 +1202,14 @@ parseMetadataEntry vt mt pm (fromEntry -> Just r) =
       return $! updateMetadataTable
         (addDebugInfo isDistinct (DebugInfoLabel dil)) pm
 
-    41 -> label "METADATA_STRING_TYPE" $ do
-      notImplemented
+    41 -> mdNotImplemented "METADATA_STRING_TYPE"
 
     -- Codes 42 and 43 are reserved for Fortran array–specific debug info, see
     -- https://github.com/llvm/llvm-project/blob/4681f6111e655057f5015564a9bf3705f87495bf/llvm/include/llvm/Bitcode/LLVMBitCodes.h#L348-L349
 
-    44 -> label "METADATA_COMMON_BLOCK" $ do
-      notImplemented
+    44 -> mdNotImplemented "METADATA_COMMON_BLOCK"
 
-    45 -> label "METADATA_GENERIC_SUBRANGE" $ do
-      notImplemented
+    45 -> mdNotImplemented "METADATA_GENERIC_SUBRANGE"
 
     46 -> label "METADATA_ARG_LIST" $ do
       cxt <- getContext

--- a/src/Data/LLVM/BitCode/IR/Metadata.hs
+++ b/src/Data/LLVM/BitCode/IR/Metadata.hs
@@ -455,14 +455,16 @@ parseMetadataEntry vt mt pm (fromEntry -> Just r) =
             (Just . ValMdValue . Typed (PrimType (Integer 64)) . ValInteger)
             (parseField r n numeric)
 
+      -- Used when some sort of placeholder entry must be added to the metadata
+      -- table, because it may be cross-reference by other metadata; here we use
+      -- an empty expression as that placeholder.
+      placeholderRecord :: DebugInfo' Int
+      placeholderRecord = DebugInfoExpression $ DIExpression mempty
+
       mdNotImplemented :: String -> Parse PartialMetadata
       mdNotImplemented name = do
         addParseWarning $ UnsupportedMetadataRecordCode (recordCode r) name
-        -- Some sort of placeholder entry must be added to the metadata table,
-        -- because it may be cross-reference by other metadata; here we use an
-        -- empty expression as that placeholder.
-        return $! updateMetadataTable
-          (addDebugInfo False (DebugInfoExpression $ DIExpression mempty)) pm
+        return $! updateMetadataTable (addDebugInfo False placeholderRecord) pm
 
   -- Note: the parsing cases below use a Monadic coding style, as opposed to an
   -- Applicative style (as was originally used) for performance reasons:
@@ -1284,7 +1286,9 @@ parseMetadataEntry vt mt pm (fromEntry -> Just r) =
       return $! updateMetadataTable
         (addDebugInfo isDistinct (DebugInfoFixedPointType difpt)) pm
 
-    code -> fail ("unknown record code: " ++ show code)
+    _ -> do
+      addParseWarning $ UnknownMetadataRecordCode (recordCode r)
+      return $! updateMetadataTable (addDebugInfo False placeholderRecord) pm
 
 parseMetadataEntry _ _ pm (abbrevDef -> Just _) =
   return pm

--- a/src/Data/LLVM/BitCode/IR/Metadata.hs
+++ b/src/Data/LLVM/BitCode/IR/Metadata.hs
@@ -456,7 +456,7 @@ parseMetadataEntry vt mt pm (fromEntry -> Just r) =
             (parseField r n numeric)
 
       -- Used when some sort of placeholder entry must be added to the metadata
-      -- table, because it may be cross-reference by other metadata; here we use
+      -- table, because it may be cross-referenced by other metadata; here we use
       -- an empty expression as that placeholder.
       placeholderRecord :: DebugInfo' Int
       placeholderRecord = DebugInfoExpression $ DIExpression mempty

--- a/src/Data/LLVM/BitCode/Parse.hs
+++ b/src/Data/LLVM/BitCode/Parse.hs
@@ -806,6 +806,10 @@ data ParseWarning
     -- the @[String]@ is the stack trace at the point where the warning was
     -- emitted.
     InvalidMetadataRecordSize !Int !MetadataRecordSizeRange ![String]
+    -- | The parser encountered a metadata record code that it is aware of, but
+    -- does notknow how to parse, where the 'Int' is the record code value and
+    -- the 'String' is the associated name of the record type.
+  | UnsupportedMetadataRecordCode !Int !String
   deriving Show
 
 -- | The expected size of a metadata record.
@@ -847,6 +851,10 @@ ppParseWarning (InvalidMetadataRecordSize len range cxt) =
           "Expected one of:" PP.<+> PP.pPrint ns
         MetadataRecordSizeAtLeast lb ->
           "Expected size of" PP.<+> PP.pPrint lb PP.<+> "or greater"
+ppParseWarning (UnsupportedMetadataRecordCode code name) =
+  "Unsupported metadata record:"
+  PP.<+> PP.text name
+  PP.<+> PP.parens (PP.pPrint code)
 
 -- | Pretty-print a group of 'ParseWarning's in a format suitable for
 -- user-facing messages.
@@ -861,10 +869,11 @@ ppParseWarnings warnings
         (\warning ->
           PP.nest 4 $ PP.vcat [ppParseWarning warning, ""])
         (F.toList warnings) ++
-      [supportMsg | any isInvalidMetadataRecordSize warnings]
+      [supportMsg | any maybeBadVersion warnings]
   where
-    isInvalidMetadataRecordSize :: ParseWarning -> Bool
-    isInvalidMetadataRecordSize (InvalidMetadataRecordSize {}) = True
+    maybeBadVersion :: ParseWarning -> Bool
+    maybeBadVersion (InvalidMetadataRecordSize {}) = True
+    maybeBadVersion _ = False
 
     supportMsg :: PP.Doc
     supportMsg =

--- a/src/Data/LLVM/BitCode/Parse.hs
+++ b/src/Data/LLVM/BitCode/Parse.hs
@@ -810,6 +810,9 @@ data ParseWarning
     -- does notknow how to parse, where the 'Int' is the record code value and
     -- the 'String' is the associated name of the record type.
   | UnsupportedMetadataRecordCode !Int !String
+    -- | The parser encountered a metadata record code that it is not aware of,
+    -- where the 'Int' is the record code value.
+  | UnknownMetadataRecordCode !Int
   deriving Show
 
 -- | The expected size of a metadata record.
@@ -855,6 +858,8 @@ ppParseWarning (UnsupportedMetadataRecordCode code name) =
   "Unsupported metadata record:"
   PP.<+> PP.text name
   PP.<+> PP.parens (PP.pPrint code)
+ppParseWarning (UnknownMetadataRecordCode code) =
+  "Unrecognized metadata record code:" PP.<+> PP.pPrint code
 
 -- | Pretty-print a group of 'ParseWarning's in a format suitable for
 -- user-facing messages.
@@ -873,6 +878,7 @@ ppParseWarnings warnings
   where
     maybeBadVersion :: ParseWarning -> Bool
     maybeBadVersion (InvalidMetadataRecordSize {}) = True
+    maybeBadVersion (UnknownMetadataRecordCode {}) = True
     maybeBadVersion _ = False
 
     supportMsg :: PP.Doc


### PR DESCRIPTION
Fixes #355.