### PR TITLE
Parse constant integer values as signed.

### DIFF
--- a/src/Data/LLVM/BitCode/IR/Constants.hs
+++ b/src/Data/LLVM/BitCode/IR/Constants.hs
@@ -262,7 +262,7 @@ parseConstantEntry t (getTy,cs) (fromEntry -> Just r) =
                 -- `0`, but `true` may be encoded as `1` or `-1`.
                 Integer 1 <- elimPrimType ty
                 return (ValBool (n /= 0))
-    return (getTy, Typed ty val:cs)
+    return (getTy, asSignedTypedVal (Typed ty val):cs)
 
   -- [n x value]
   5 -> label "CST_CODE_WIDE_INTEGER" $ do
@@ -453,10 +453,7 @@ parseConstantEntry t (getTy,cs) (fromEntry -> Just r) =
                   | otherwise  = ValVector (PrimType elemTy) elems
           return (getTy, Typed ty val : cs)
     case elemTy of
-      Integer 8          -> build ValInteger
-      Integer 16         -> build ValInteger
-      Integer 32         -> build ValInteger
-      Integer 64         -> build ValInteger
+      Integer n          -> build (ValInteger . asSignedInt n)
       FloatType Float    -> build (ValFloat . castFloat)
       FloatType Double   -> build (ValDouble . castDouble)
       x                  -> Assert.unknownEntity "element type" x

--- a/src/Data/LLVM/BitCode/IR/Metadata.hs
+++ b/src/Data/LLVM/BitCode/IR/Metadata.hs
@@ -54,7 +54,7 @@ import           Data.Maybe (fromMaybe, mapMaybe)
 import           Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import           Data.Typeable (Typeable)
-import           Data.Word (Word8,Word16,Word32,Word64)
+import           Data.Word (Word8,Word32,Word64)
 
 import           GHC.Generics (Generic)
 import           GHC.Stack (HasCallStack, callStack)
@@ -421,24 +421,8 @@ parseMetadataEntry vt mt pm (fromEntry -> Just r) =
                  mdForwardRefOrNull ctx mt <$> parseMdIdx r n
       ronl n = if length (recordFields r) <= n then pure Nothing else ron n
 
-      -- Converts from the parsed raw numeric value (a two's-complement
-      -- representation) into a native positive or negative value.
       asSignedVal = fmap $ \case
-        v@(ValMdValue tv)
-          | PrimType (Integer s) <- typedType tv
-          , ValInteger i <- typedValue tv
-            -> let checkNeg x =
-                     if testBit x (fromEnum $ s - 1)
-                     then
-                       let xNeg = toInteger (complement x + 1) * (-1)
-                       in ValMdValue $ tv { typedValue = ValInteger xNeg }
-                     else v
-               in case s of
-                    8  -> checkNeg (fromInteger i :: Word8)
-                    16 -> checkNeg (fromInteger i :: Word16)
-                    32 -> checkNeg (fromInteger i :: Word32)
-                    64 -> checkNeg (fromInteger i :: Word64)
-                    _  -> v
+        ValMdValue tv -> ValMdValue $ asSignedTypedVal tv
         o -> o
 
       -- If the @isMetadata@ argument is 'True', then parse a metadata value

--- a/src/Data/LLVM/BitCode/Parse.hs
+++ b/src/Data/LLVM/BitCode/Parse.hs
@@ -2,11 +2,12 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecursiveDo #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE RecursiveDo #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 
 module Data.LLVM.BitCode.Parse where
 
@@ -24,11 +25,12 @@ import           Control.Monad.Except (MonadError(..), Except, runExcept)
 import           Control.Monad.Reader (MonadReader(..), ReaderT(..), asks)
 import           Control.Monad.State.Strict (MonadState(..), StateT(..)
                                             , gets, modify)
+import           Data.Bits ( testBit, complement )
 import qualified Data.Foldable as F
 import           Data.Maybe (fromMaybe)
 import           Data.Semigroup
 import           Data.Typeable (Typeable)
-import           Data.Word ( Word32 )
+import           Data.Word ( Word8, Word16, Word32, Word64 )
 
 import qualified Codec.Binary.UTF8.String as UTF8 (decode)
 import qualified Control.Exception as X
@@ -597,6 +599,28 @@ getTypeId n = do
   case Map.lookup n (tsByName symtab) of
     Just ix -> return ix
     Nothing -> fail ("unknown type alias " ++ show (ppLLVM llvmVlatest (llvmPP n)))
+
+-- | Convert a raw two's-complement value of the size specified in the first
+-- argument into a signed value.
+asSignedInt :: (Eq bitsize, Num bitsize, Enum bitsize)
+            => bitsize ->  Integer -> Integer
+asSignedInt nbits val =
+  let checkNeg x = if testBit x (fromEnum $ nbits - 1)
+                   then toInteger (complement x + 1) * (-1)
+                   else toInteger x
+  in case nbits of
+       8  -> checkNeg (fromInteger val :: Word8)
+       16 -> checkNeg (fromInteger val :: Word16)
+       32 -> checkNeg (fromInteger val :: Word32)
+       64 -> checkNeg (fromInteger val :: Word64)
+       _  -> val
+
+asSignedTypedVal :: Typed (Value' lab) -> Typed (Value' lab)
+asSignedTypedVal = \case
+  tv@(Typed { typedType = PrimType (Integer s)
+            , typedValue = ValInteger i
+            }) -> tv { typedValue = ValInteger $ asSignedInt s i }
+  tv -> tv
 
 
 -- Value Symbol Table ----------------------------------------------------------


### PR DESCRIPTION
Prior to this, the constant values were parsed and stored in their raw, two's-complement unsigned value.  This was visible as seen in the following:

```
$ cabal run disasm-test -- -p p0 --details true | grep -A4'__const.main.msg .* constant'
...
--
-@__const.main.msg = private constant { i16, [6 x i8], ptr, i8, [7 x i8] } { i16 0, [6 x i8] zeroinitializer, ptr @signal, i8 -56, [7 x i8] zeroinitializer }, align 8
-
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #0
-
--
+@__const.main.msg = private default constant { i16, [6 x i8], ptr,
+                                               i8, [7 x i8] } { i16 0, [6 x i8] zeroinitializer,
+                                                                ptr @signal,
+                                                                i8 18446744073709551560,
+                                                                [7 x i8] zeroinitializer }, align 8

```

Note that the first initialization shown (the output from LLVM's `llvm-dis`) specifies the third value as `i8 -56`, whereas the second initialization shown (the output from this package's `llvm-disasm`) specifies that same value as `i8 18446744073709551560`, which is silly and brittle.

With this change, the parsing properly converts the two's-complement unsigned integer value into a signed value and the `llvm-disasm` output of these values now matches that of `llvm-dis`.